### PR TITLE
Add custom marshalling and unmarshalling for 'internal/db/money.Money' type

### DIFF
--- a/internal/db/money/money.go
+++ b/internal/db/money/money.go
@@ -1,9 +1,28 @@
 package money
 
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+var (
+	_ json.Marshaler   = (*Money)(nil)
+	_ json.Unmarshaler = (*Money)(nil)
+)
+
 // Money is a sum of money multiplied by presicion (100). It can be negative
+// Money is marshalled without multiplication:
+//   - FromInt(15) -> 15
+//   - FromFloat(15.07) -> 15.07
+//   - FromFloat(15.073) -> 15.07
+//   - FromFloat(15.078) -> 15.07
+//
 type Money int64
 
+// -------------------------------------------------
 // Convert functions
+// -------------------------------------------------
 
 const precision = 100
 
@@ -27,7 +46,9 @@ func (m Money) ToFloat() float64 {
 	return float64(m) / precision
 }
 
+// -------------------------------------------------
 // Add functions
+// -------------------------------------------------
 
 // Add returns sum of original and passed Moneys
 func (m Money) Add(add Money) Money {
@@ -44,7 +65,9 @@ func (m Money) AddFloat(add float64) Money {
 	return m + FromFloat(add)
 }
 
+// -------------------------------------------------
 // Sub functions
+// -------------------------------------------------
 
 // Sub returns remainder after substraction
 func (m Money) Sub(sub Money) Money {
@@ -70,4 +93,28 @@ func (m Money) Divide(n int64) Money {
 	// Don't use Money.ToInt for better precision
 	money := int64(m)
 	return Money(money / n)
+}
+
+// -------------------------------------------------
+// Marshalling and Unmarshalling
+// -------------------------------------------------
+
+func (m Money) MarshalJSON() ([]byte, error) {
+	var str string
+	if m%precision == 0 {
+		// We can skip ".00" because we won't lose any significant digits
+		str = strconv.FormatInt(m.ToInt(), 10)
+	} else {
+		str = fmt.Sprintf("%.2f", m.ToFloat())
+	}
+	return []byte(str), nil
+}
+
+func (m *Money) UnmarshalJSON(data []byte) error {
+	f, err := strconv.ParseFloat(string(data), 64)
+	if err != nil {
+		return err
+	}
+	*m = FromFloat(f)
+	return nil
 }

--- a/internal/db/money/money_test.go
+++ b/internal/db/money/money_test.go
@@ -1,6 +1,7 @@
 package money_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -228,4 +229,98 @@ func TestDivide(t *testing.T) {
 		require.Equal(tt.resInt, res.ToInt())
 		require.Equal(tt.resFloat, res.ToFloat())
 	}
+}
+
+func TestJSON(t *testing.T) {
+	type testStruct struct {
+		Money Money `json:"money"`
+	}
+
+	t.Run("Marshal", func(t *testing.T) {
+		require := require.New(t)
+
+		tests := []struct {
+			input testStruct
+			want  string
+		}{
+			{
+				input: testStruct{
+					Money: FromInt(357),
+				},
+				want: `{"money":357}`,
+			},
+			{
+				input: testStruct{
+					Money: FromFloat(154.30),
+				},
+				want: `{"money":154.30}`,
+			},
+			{
+				input: testStruct{
+					Money: FromFloat(0.07),
+				},
+				want: `{"money":0.07}`,
+			},
+			{
+				input: testStruct{
+					Money: FromFloat(15.073),
+				},
+				want: `{"money":15.07}`,
+			},
+			{
+				input: testStruct{
+					Money: FromFloat(15.078),
+				},
+				want: `{"money":15.07}`,
+			},
+		}
+
+		for _, tt := range tests {
+			data, err := json.Marshal(tt.input)
+			require.Nil(err)
+			require.Equal(tt.want, string(data))
+		}
+	})
+
+	t.Run("Unmarshal", func(t *testing.T) {
+		require := require.New(t)
+
+		tests := []struct {
+			input string
+			want  testStruct
+		}{
+			{
+				input: `{"money":357}`,
+				want: testStruct{
+					Money: FromInt(357),
+				},
+			},
+			{
+				input: `{"money":154.30}`,
+				want: testStruct{
+					Money: FromFloat(154.30),
+				},
+			},
+			{
+				input: `{"money":0.07}`,
+				want: testStruct{
+					Money: FromFloat(0.07),
+				},
+			},
+			{
+				input: `{"money":"test"}`,
+				want: testStruct{
+					Money: FromInt(0),
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			var res testStruct
+
+			// Ignore errors
+			_ = json.Unmarshal([]byte(tt.input), &res)
+			require.Equal(tt.want, res)
+		}
+	})
 }


### PR DESCRIPTION
`Money` is marshalled without multiplication:

| From | Money internal value | Marshalled
| -- | -- | -- |
| 15 | 1500 | 15
| 15.07 | 1507 | 15.07
| 15.073 | 1507 | 15.07
| 15.078 | 1507 | 15.07
