### PR TITLE
Ignore trailing slashes in URLs

### DIFF
--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -96,6 +96,7 @@ func NewServer(cnf Config, db *db.DB, log *clog.Logger, debug bool) *Server {
 
 func (s *Server) Prepare() {
 	router := mux.NewRouter()
+	router.StrictSlash(true)
 
 	// Add middlewares
 


### PR DESCRIPTION
`GET /overview/2020/1/` will be redirected to `GET /overview/2020/1`