### PR TITLE
Small fixes and improvements

### DIFF
--- a/cmd/budget-manager/main.go
+++ b/cmd/budget-manager/main.go
@@ -173,14 +173,14 @@ func (app *App) Shutdown() {
 	app.log.Info("shutdown web server")
 	err := app.server.Shutdown()
 	if err != nil {
-		app.log.WithError(err).Error("can't shutdown the server gracefully")
+		app.log.WithError(err).Error("couldn't shutdown the server gracefully")
 	}
 
 	// Database
 	app.log.Info("shutdown the database")
 	err = app.db.Shutdown()
 	if err != nil {
-		app.log.WithError(err).Error("can't shutdown the db gracefully")
+		app.log.WithError(err).Error("couldn't shutdown the db gracefully")
 	}
 
 	app.log.Info("shutdowns are completed")

--- a/internal/db/pg/common.go
+++ b/internal/db/pg/common.go
@@ -200,7 +200,7 @@ func (db DB) recomputeMonth(tx *pg.Tx, monthID uint) error {
 	m, err := db.getMonth(tx, monthID)
 	if err != nil {
 		return errors.Wrap(err,
-			errors.WithMsg("can't select month"),
+			errors.WithMsg("couldn't select month"),
 			errors.WithType(errors.AppError))
 	}
 
@@ -265,7 +265,7 @@ func (db DB) recomputeMonth(tx *pg.Tx, monthID uint) error {
 	err = tx.Update(m)
 	if err != nil {
 		return errors.Wrap(err,
-			errors.WithMsg("can't update month"),
+			errors.WithMsg("couldn't the update month"),
 			errors.WithType(errors.AppError))
 	}
 
@@ -273,7 +273,7 @@ func (db DB) recomputeMonth(tx *pg.Tx, monthID uint) error {
 	_, err = tx.Model(&m.Days).Update()
 	if err != nil {
 		return errors.Wrap(err,
-			errors.WithMsg("can't update days"),
+			errors.WithMsg("couldn't the update days"),
 			errors.WithType(errors.AppError))
 	}
 
@@ -351,6 +351,6 @@ func (db DB) checkModel(model interface{}) (ok bool) {
 
 func errRecomputeBudget(err error) error {
 	return errors.Wrap(err,
-		errors.WithMsg("can't recompute month budget"),
+		errors.WithMsg("couldn't recompute the month budget"),
 		errors.WithType(errors.AppError))
 }

--- a/internal/db/pg/common.go
+++ b/internal/db/pg/common.go
@@ -79,7 +79,7 @@ func (DB) getMonthIDByDayID(_ context.Context, tx *pg.Tx, dayID uint) (uint, err
 		}
 
 		return 0, errors.Wrap(err,
-			errors.WithMsg("coudln't select day with passed id"),
+			errors.WithMsg("couldn't select day with passed id"),
 			errors.WithType(errors.AppError))
 	}
 

--- a/internal/db/pg/income.go
+++ b/internal/db/pg/income.go
@@ -188,7 +188,7 @@ func (db DB) RemoveIncome(ctx context.Context, id uint) error {
 		return nil
 	})
 	if err != nil {
-		log.WithError(errors.GetOriginalError(err)).Error("coudln't remove Income")
+		log.WithError(errors.GetOriginalError(err)).Error("couldn't remove Income")
 		return err
 	}
 

--- a/internal/db/pg/income.go
+++ b/internal/db/pg/income.go
@@ -29,7 +29,7 @@ func (db DB) AddIncome(ctx context.Context, args db_common.AddIncomeArgs) (incom
 		incomeID, err = db.addIncome(tx, args)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't add a new Income"),
+				errors.WithMsg("couldn't add a new Income"),
 				errors.WithTypeIfNotSet(errors.AppError))
 		}
 
@@ -94,14 +94,14 @@ func (db DB) EditIncome(ctx context.Context, args db_common.EditIncomeArgs) erro
 			if err == pg.ErrNoRows {
 				return db_common.ErrIncomeNotExist
 			}
-			return errors.Wrap(err, errors.WithMsg("can't select Income"), errors.WithType(errors.AppError))
+			return errors.Wrap(err, errors.WithMsg("couldn't select Income"), errors.WithType(errors.AppError))
 		}
 
 		// Edit Income
 		err = db.editIncome(tx, in, args)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't edit the Income"),
+				errors.WithMsg("couldn't edit the Income"),
 				errors.WithTypeIfNotSet(errors.AppError))
 		}
 
@@ -167,7 +167,7 @@ func (db DB) RemoveIncome(ctx context.Context, id uint) error {
 		}()
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't select Income with passed id"),
+				errors.WithMsg("couldn't select Income with passed id"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -175,7 +175,7 @@ func (db DB) RemoveIncome(ctx context.Context, id uint) error {
 		err = db.removeIncome(tx, id)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't remove Income with passed id"),
+				errors.WithMsg("couldn't remove Income with passed id"),
 				errors.WithTypeIfNotSet(errors.AppError))
 		}
 

--- a/internal/db/pg/monthly_payment.go
+++ b/internal/db/pg/monthly_payment.go
@@ -29,7 +29,7 @@ func (db DB) AddMonthlyPayment(ctx context.Context, args db_common.AddMonthlyPay
 		id, err = db.addMonthlyPayment(tx, args)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't add a new Monthly Payment"),
+				errors.WithMsg("couldn't add a new Monthly Payment"),
 				errors.WithTypeIfNotSet(errors.AppError))
 		}
 
@@ -91,7 +91,7 @@ func (db DB) EditMonthlyPayment(ctx context.Context, args db_common.EditMonthlyP
 				return db_common.ErrMonthlyPaymentNotExist
 			}
 			return errors.Wrap(err,
-				errors.WithMsg("can't get Monthly Payment with passed id"),
+				errors.WithMsg("couldn't get Monthly Payment with passed id"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -99,7 +99,7 @@ func (db DB) EditMonthlyPayment(ctx context.Context, args db_common.EditMonthlyP
 		err = db.editMonthlyPayment(tx, mp, args)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't edit the Monthly Payment"),
+				errors.WithMsg("couldn't edit the Monthly Payment"),
 				errors.WithTypeIfNotSet(errors.AppError))
 		}
 
@@ -157,14 +157,14 @@ func (db DB) RemoveMonthlyPayment(ctx context.Context, id uint) error {
 		err = tx.Model(mp).Column("month_id").WherePK().Select()
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't select Monthly Payment with passed id"),
+				errors.WithMsg("couldn't select Monthly Payment with passed id"),
 				errors.WithType(errors.AppError))
 		}
 
 		err = tx.Delete(mp)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't remove Monthly Payment"),
+				errors.WithMsg("couldn't remove Monthly Payment"),
 				errors.WithType(errors.AppError))
 		}
 

--- a/internal/db/pg/pg.go
+++ b/internal/db/pg/pg.go
@@ -91,7 +91,7 @@ func (db *DB) Prepare() error {
 
 	err = errors.Wrap(err, "couldn't create tables")
 	if err != nil {
-		db.log.WithError(err).Error("coudln't create tables")
+		db.log.WithError(err).Error("couldn't create tables")
 		return err
 	}
 

--- a/internal/db/pg/pg.go
+++ b/internal/db/pg/pg.go
@@ -108,8 +108,9 @@ func (db *DB) Prepare() error {
 		}
 	})
 	if err != nil {
-		db.log.WithError(err).Error("can't add function to cron")
-		return errors.Wrap(err, "could't add function to cron")
+		const msg = "couldn't add a function to cron"
+		db.log.WithError(err).Error(msg)
+		return errors.Wrap(err, msg)
 	}
 
 	// Start cron
@@ -155,8 +156,9 @@ func (db *DB) initCurrentMonth() error {
 
 	currentMonth := &Month{Year: year, Month: month}
 	if err = db.db.Insert(currentMonth); err != nil {
-		log.WithError(err).Error("could't init the current month")
-		return errors.Wrap(err, "could't init the current month")
+		const msg = "couldn't init the current month"
+		log.WithError(err).Error(msg)
+		return errors.Wrap(err, msg)
 	}
 
 	monthID := currentMonth.ID

--- a/internal/db/pg/spend.go
+++ b/internal/db/pg/spend.go
@@ -50,7 +50,7 @@ func (db DB) AddSpend(ctx context.Context, args db_common.AddSpendArgs) (id uint
 		return nil
 	})
 	if err != nil {
-		log.WithError(errors.GetOriginalError(err)).Error("coudln't create a new Spend")
+		log.WithError(errors.GetOriginalError(err)).Error("couldn't create a new Spend")
 		return 0, err
 	}
 
@@ -199,7 +199,7 @@ func (db DB) RemoveSpend(ctx context.Context, id uint) error {
 		return nil
 	})
 	if err != nil {
-		log.WithError(errors.GetOriginalError(err)).Error("coudln't remove the Spend")
+		log.WithError(errors.GetOriginalError(err)).Error("couldn't remove the Spend")
 		return err
 	}
 

--- a/internal/db/pg/spend.go
+++ b/internal/db/pg/spend.go
@@ -29,7 +29,7 @@ func (db DB) AddSpend(ctx context.Context, args db_common.AddSpendArgs) (id uint
 		id, err = db.addSpend(tx, args)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't add a new Spend"),
+				errors.WithMsg("couldn't add a new Spend"),
 				errors.WithTypeIfNotSet(errors.AppError))
 		}
 
@@ -38,7 +38,7 @@ func (db DB) AddSpend(ctx context.Context, args db_common.AddSpendArgs) (id uint
 		monthID, err := db.getMonthIDByDayID(ctx, tx, args.DayID)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't get Month which contains Day with passed dayID"),
+				errors.WithMsg("couldn't get Month which contains Day with passed dayID"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -96,7 +96,7 @@ func (db DB) EditSpend(ctx context.Context, args db_common.EditSpendArgs) error 
 		err = tx.Select(spend)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't select Spend with passed id"),
+				errors.WithMsg("couldn't select Spend with passed id"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -104,7 +104,7 @@ func (db DB) EditSpend(ctx context.Context, args db_common.EditSpendArgs) error 
 		err = db.editSpend(tx, spend, args)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't edit the Spend"),
+				errors.WithMsg("couldn't edit the Spend"),
 				errors.WithTypeIfNotSet(errors.AppError))
 		}
 
@@ -113,7 +113,7 @@ func (db DB) EditSpend(ctx context.Context, args db_common.EditSpendArgs) error 
 		monthID, err := db.getMonthIDByDayID(ctx, tx, spend.DayID)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't get Month which contains Day with passed dayID"),
+				errors.WithMsg("couldn't get Month which contains Day with passed dayID"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -170,7 +170,7 @@ func (db DB) RemoveSpend(ctx context.Context, id uint) error {
 		err = tx.Model(spend).Column("day_id").WherePK().Select()
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't select Spend with passed id"),
+				errors.WithMsg("couldn't select Spend with passed id"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -178,7 +178,7 @@ func (db DB) RemoveSpend(ctx context.Context, id uint) error {
 		err = tx.Delete(spend)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't delete Spend with passed id"),
+				errors.WithMsg("couldn't delete Spend with passed id"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -187,7 +187,7 @@ func (db DB) RemoveSpend(ctx context.Context, id uint) error {
 		monthID, err := db.getMonthIDByDayID(ctx, tx, spend.DayID)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't get Month which contains Day with passed dayID"),
+				errors.WithMsg("couldn't get Month which contains Day with passed dayID"),
 				errors.WithType(errors.AppError))
 		}
 

--- a/internal/db/pg/spend_type.go
+++ b/internal/db/pg/spend_type.go
@@ -25,7 +25,7 @@ func (db DB) GetSpendType(ctx context.Context, id uint) (*db_common.SpendType, e
 				errors.WithType(errors.UserError))
 		} else {
 			err = errors.Wrap(err,
-				errors.WithMsg("can't select Spend Type"),
+				errors.WithMsg("couldn't select Spend Type"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -45,7 +45,7 @@ func (db DB) GetSpendTypes(ctx context.Context) ([]*db_common.SpendType, error) 
 	err := db.db.Model(&spendTypes).Order("id ASC").Select()
 	if err != nil {
 		err = errors.Wrap(err,
-			errors.WithMsg("can't select Spend Types"),
+			errors.WithMsg("couldn't select Spend Types"),
 			errors.WithType(errors.AppError))
 
 		log.WithError(errors.GetOriginalError(err)).Error("couldn't get all Spend Types")
@@ -68,13 +68,13 @@ func (db DB) AddSpendType(ctx context.Context, name string) (typeID uint, err er
 	spendType := &SpendType{Name: name}
 	err = db.db.RunInTransaction(func(tx *pg.Tx) (err error) {
 		if err := checkModel(spendType); err != nil {
-			return errors.Wrap(err, errors.WithMsg("can't add a new Spend Type"))
+			return errors.Wrap(err, errors.WithMsg("couldn't add a new Spend Type"))
 		}
 
 		err = tx.Insert(spendType)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't add a new Spend Type"),
+				errors.WithMsg("couldn't add a new Spend Type"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -103,13 +103,13 @@ func (db DB) EditSpendType(ctx context.Context, id uint, newName string) error {
 	spendType := &SpendType{ID: id, Name: newName}
 	err := db.db.RunInTransaction(func(tx *pg.Tx) (err error) {
 		if err := checkModel(spendType); err != nil {
-			return errors.Wrap(err, errors.WithMsg("can't edit the Spend Type"))
+			return errors.Wrap(err, errors.WithMsg("couldn't edit the Spend Type"))
 		}
 
 		err = tx.Update(spendType)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't edit the Spend Type"),
+				errors.WithMsg("couldn't edit the Spend Type"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -140,7 +140,7 @@ func (db DB) RemoveSpendType(ctx context.Context, id uint) error {
 		err = tx.Delete(spendType)
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't delete Spend Type"),
+				errors.WithMsg("couldn't delete Spend Type"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -152,7 +152,7 @@ func (db DB) RemoveSpendType(ctx context.Context, id uint) error {
 			Update()
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't reset Type IDs of Monthly Payments"),
+				errors.WithMsg("couldn't reset Type IDs of Monthly Payments"),
 				errors.WithType(errors.AppError))
 		}
 
@@ -162,7 +162,7 @@ func (db DB) RemoveSpendType(ctx context.Context, id uint) error {
 			Update()
 		if err != nil {
 			return errors.Wrap(err,
-				errors.WithMsg("can't reset Type IDs of Spends"),
+				errors.WithMsg("couldn't reset Type IDs of Spends"),
 				errors.WithType(errors.AppError))
 		}
 

--- a/internal/db/pg/spend_type.go
+++ b/internal/db/pg/spend_type.go
@@ -48,7 +48,7 @@ func (db DB) GetSpendTypes(ctx context.Context) ([]*db_common.SpendType, error) 
 			errors.WithMsg("can't select Spend Types"),
 			errors.WithType(errors.AppError))
 
-		log.WithError(errors.GetOriginalError(err)).Error("coudln't get all Spend Types")
+		log.WithError(errors.GetOriginalError(err)).Error("couldn't get all Spend Types")
 		return nil, err
 	}
 
@@ -81,7 +81,7 @@ func (db DB) AddSpendType(ctx context.Context, name string) (typeID uint, err er
 		return nil
 	})
 	if err != nil {
-		log.WithError(errors.GetOriginalError(err)).Error("coudln't add a new Spend Type")
+		log.WithError(errors.GetOriginalError(err)).Error("couldn't add a new Spend Type")
 		return 0, err
 	}
 
@@ -169,7 +169,7 @@ func (db DB) RemoveSpendType(ctx context.Context, id uint) error {
 		return nil
 	})
 	if err != nil {
-		log.WithError(errors.GetOriginalError(err)).Error("coudln't remove the Spend Type")
+		log.WithError(errors.GetOriginalError(err)).Error("couldn't remove the Spend Type")
 		return err
 	}
 

--- a/internal/db/pg/utils.go
+++ b/internal/db/pg/utils.go
@@ -45,7 +45,7 @@ func createTables(db *pg.DB, modelsAndOpts ...interface{}) error {
 
 		err := db.CreateTable(model, opts)
 		if err != nil {
-			return pkgErrors.Wrap(err, "can't create table")
+			return pkgErrors.Wrap(err, "couldn't create a table")
 		}
 	}
 
@@ -79,7 +79,7 @@ func dropTables(db *pg.DB, modelsAndOpts ...interface{}) error {
 
 		err := db.DropTable(model, opts)
 		if err != nil {
-			return pkgErrors.Wrap(err, "can't drop table")
+			return pkgErrors.Wrap(err, "couldn't drop a table")
 		}
 	}
 

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -105,7 +105,7 @@ func testHandlers_Income_AddIncome(t *testing.T, server *Server) {
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't add a new Income: title can't be empty",
+				Error:     "couldn't add a new Income: title can't be empty",
 				Success:   false,
 			},
 		},
@@ -120,7 +120,7 @@ func testHandlers_Income_AddIncome(t *testing.T, server *Server) {
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't add a new Income: invalid income: '0'",
+				Error:     "couldn't add a new Income: invalid income: '0'",
 				Success:   false,
 			},
 		},
@@ -246,7 +246,7 @@ func testHandlers_Income_EditIncome(t *testing.T, server *Server) {
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't edit the Income: invalid income: '0'",
+				Error:     "couldn't edit the Income: invalid income: '0'",
 				Success:   false,
 			},
 		},
@@ -429,7 +429,7 @@ func testHandlers_MonthlyPayment_AddMonthlyPayment(t *testing.T, server *Server)
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't add a new Monthly Payment: title can't be empty",
+				Error:     "couldn't add a new Monthly Payment: title can't be empty",
 				Success:   false,
 			},
 		},
@@ -444,7 +444,7 @@ func testHandlers_MonthlyPayment_AddMonthlyPayment(t *testing.T, server *Server)
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't add a new Monthly Payment: invalid cost: '0'",
+				Error:     "couldn't add a new Monthly Payment: invalid cost: '0'",
 				Success:   false,
 			},
 		},
@@ -572,7 +572,7 @@ func testHandlers_MonthlyPayment_EditMonthlyPayment(t *testing.T, server *Server
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't edit the Monthly Payment: invalid cost: '0'",
+				Error:     "couldn't edit the Monthly Payment: invalid cost: '0'",
 				Success:   false,
 			},
 		},
@@ -740,7 +740,7 @@ func testHandlers_Spend_AddSpend(t *testing.T, server *Server) {
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't add a new Spend: title can't be empty",
+				Error:     "couldn't add a new Spend: title can't be empty",
 				Success:   false,
 			},
 		},
@@ -752,7 +752,7 @@ func testHandlers_Spend_AddSpend(t *testing.T, server *Server) {
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't add a new Spend: invalid cost: '0'",
+				Error:     "couldn't add a new Spend: invalid cost: '0'",
 				Success:   false,
 			},
 		},
@@ -862,7 +862,7 @@ func testHandlers_Spend_EditSpend(t *testing.T, server *Server) {
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't edit the Spend: title can't be empty",
+				Error:     "couldn't edit the Spend: title can't be empty",
 				Success:   false,
 			},
 		},
@@ -892,7 +892,7 @@ func testHandlers_Spend_EditSpend(t *testing.T, server *Server) {
 			statusCode: http.StatusBadRequest,
 			resp: models.Response{
 				RequestID: requestID.ToString(),
-				Error:     "can't edit the Spend: invalid cost: '0'",
+				Error:     "couldn't edit the Spend: invalid cost: '0'",
 				Success:   false,
 			},
 		},
@@ -1053,7 +1053,7 @@ func TestHandlers_SpendType(t *testing.T) {
 				statusCode: http.StatusBadRequest,
 				resp: models.Response{
 					RequestID: requestID.ToString(),
-					Error:     "can't add a new Spend Type: name can't be empty",
+					Error:     "couldn't add a new Spend Type: name can't be empty",
 					Success:   false,
 				},
 			},
@@ -1164,7 +1164,7 @@ func TestHandlers_SpendType(t *testing.T) {
 				statusCode: http.StatusBadRequest,
 				resp: models.Response{
 					RequestID: requestID.ToString(),
-					Error:     "can't edit the Spend Type: name can't be empty",
+					Error:     "couldn't edit the Spend Type: name can't be empty",
 					Success:   false,
 				},
 			},

--- a/internal/web/pages.go
+++ b/internal/web/pages.go
@@ -130,14 +130,14 @@ func (s Server) monthPage(w http.ResponseWriter, r *http.Request) {
 	month, err := s.db.GetMonth(r.Context(), monthID)
 	if err != nil {
 		s.processErrorWithPage(
-			r.Context(), w, dbErrorMessagePrefix+"can't get Month info", http.StatusInternalServerError, err,
+			r.Context(), w, dbErrorMessagePrefix+"couldn't get Month info", http.StatusInternalServerError, err,
 		)
 		return
 	}
 
 	spendTypes, err := s.db.GetSpendTypes(r.Context())
 	if err != nil {
-		s.processErrorWithPage(r.Context(), w, dbErrorMessagePrefix+"can't get list of Spend Types",
+		s.processErrorWithPage(r.Context(), w, dbErrorMessagePrefix+"couldn't get list of Spend Types",
 			http.StatusInternalServerError, err)
 		return
 	}

--- a/internal/web/utils.go
+++ b/internal/web/utils.go
@@ -40,7 +40,7 @@ func (s Server) processError(ctx context.Context, w http.ResponseWriter, respMsg
 	code int, internalErr error) {
 
 	if internalErr != nil {
-		s.logError(respMsg, code, internalErr)
+		s.logError(ctx, respMsg, code, internalErr)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -58,7 +58,7 @@ func (s Server) processErrorWithPage(ctx context.Context, w http.ResponseWriter,
 	respMsg string, code int, internalErr error) {
 
 	if internalErr != nil {
-		s.logError(respMsg, code, internalErr)
+		s.logError(ctx, respMsg, code, internalErr)
 	}
 
 	data := struct {
@@ -75,10 +75,8 @@ func (s Server) processErrorWithPage(ctx context.Context, w http.ResponseWriter,
 	}
 }
 
-func (s Server) logError(respMsg string, code int, internalErr error) {
-	s.log.WithFields(logrus.Fields{
-		"msg":   respMsg,
-		"code":  code,
-		"error": internalErr,
-	}).Error("request error")
+func (s Server) logError(ctx context.Context, respMsg string, code int, internalErr error) {
+	log := request_id.FromContextToLogger(ctx, s.log)
+	log = log.WithFields(logrus.Fields{"msg": respMsg, "code": code, "error": internalErr})
+	log.Error("request error")
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -180,7 +180,7 @@ func (s Server) Shutdown() error {
 
 	err := s.server.Shutdown(ctx)
 	if err != nil {
-		s.log.WithError(err).Errorf("coudln't shutdown server gracefully")
+		s.log.WithError(err).Errorf("couldn't shutdown server gracefully")
 	}
 
 	return err

--- a/tools/api.rest
+++ b/tools/api.rest
@@ -6,7 +6,7 @@
 @port = 8080
 @baseUrl = {{schema}}://{{host}}:{{port}}
 @currentYear = {{$datetime "YYYY"}}
-@currentMonth = {{$datetime "MM"}}
+@currentMonth = {{$datetime "M"}}
 @dayID = 11
 @dayNumber = 11
 


### PR DESCRIPTION
- Fix `currentMonth` variable in `tools/api.rest` script
- Fix typos and inconsistent `can't`/`couldn't` (use `couldn't` everywhere)
- Pass `context.Context` into `internal/web.Server.logError` method to log request id