### PR TITLE
Fix an issue with new versions of PostgreSQL in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You need [Docker](https://docs.docker.com/install/) and [docker-compose](https:/
           - "8080:8080"
 
       postgres:
-        image: postgres
+        image: postgres:12-alpine
         container_name: budget-manager_postgres
         environment:
           POSTGRES_USER: postgres

--- a/scripts/docker/docker-compose.yml
+++ b/scripts/docker/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "8080:8080"
 
   postgres:
-    image: postgres
+    image: postgres:12-alpine
     container_name: budget-manager_postgres
     environment:
       POSTGRES_USER: postgres

--- a/scripts/docker/docker-compose.yml
+++ b/scripts/docker/docker-compose.yml
@@ -25,8 +25,9 @@ services:
     container_name: budget-manager_postgres
     environment:
       POSTGRES_USER: postgres
-      # Empty password
+      # Use empty password
       # POSTGRES_PASSWORD
+      POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_DB: postgres
     volumes:
       # Use this volume to not store data

--- a/scripts/local/postgres.sh
+++ b/scripts/local/postgres.sh
@@ -32,4 +32,4 @@ docker run --rm -d \
 	${MOUNT} \
 	-e POSTGRES_USER=postgres \
 	-e POSTGRES_DB=postgres \
-	postgres -c "log_statement=all"
+	postgres:12-alpine -c "log_statement=all"

--- a/scripts/local/postgres.sh
+++ b/scripts/local/postgres.sh
@@ -32,4 +32,5 @@ docker run --rm -d \
 	${MOUNT} \
 	-e POSTGRES_USER=postgres \
 	-e POSTGRES_DB=postgres \
+	-e POSTGRES_HOST_AUTH_METHOD=trust \
 	postgres:12-alpine -c "log_statement=all"


### PR DESCRIPTION
New PostgreSQL versions require `POSTGRES_HOST_AUTH_METHOD=trust` env variable to use empty password