### PR TITLE
Add pprof http handlers to be able to profile the app

### DIFF
--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"net/http"
+	"net/http/pprof"
 
 	"github.com/gorilla/mux"
 )
@@ -46,4 +47,12 @@ func (s Server) addRoutes(router *mux.Router) {
 	for _, r := range routes {
 		router.Methods(r.methods).Path(r.path).HandlerFunc(r.handler)
 	}
+}
+
+func (Server) addPprofRoutes(router *mux.Router) {
+	router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	router.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	router.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -144,6 +144,10 @@ func (s *Server) Prepare() {
 	// Add API routes
 	s.log.Debug("add routes")
 	s.addRoutes(router)
+	if s.config.Debug {
+		// Enable pprof handlers
+		s.addPprofRoutes(router)
+	}
 
 	// Add File Handler
 	fileHandler := http.StripPrefix("/static/", http.FileServer(http.Dir("static")))

--- a/tools/bench.sh
+++ b/tools/bench.sh
@@ -3,10 +3,12 @@
 # via 'vegeta' for 5 seconds with 25 workers
 
 YEAR=$(date +"%Y")
-MONTH=$(date +"%m")
-URL="http://localhost:8080/overview/${YEAR}/${MONTH}"
+MONTH=$(date +"%-m")
+BODY='{"year": '${YEAR}', "month": '${MONTH}'}'
+URL="http://localhost:8080/api/months"
 DURATION="5s"
 #
+REQ_BODY_FILE="bench_body"
 RESULT_FILE="results.bin"
 
 # Check whether 'vegeta' is installed
@@ -23,13 +25,17 @@ if [ "$?" != "0" ]; then
 	exit 1
 fi
 
+# Prepare a file with test body
+echo ${BODY} > ${REQ_BODY_FILE}
+
 # Start benchmark
 echo "Start benchmark for '${URL}'..."
 
-echo "GET ${URL}" | vegeta attack -duration=${DURATION} -rate=0 -max-workers=25 > ${RESULT_FILE}
+echo "GET ${URL}" | vegeta attack -body=${REQ_BODY_FILE} -duration=${DURATION} -rate=0 -max-workers=25 > ${RESULT_FILE}
 
 cat ${RESULT_FILE} | vegeta report
 cat ${RESULT_FILE} | vegeta report -type="hist[25ms,50ms,100ms,200ms,400ms]"
 
 # Cleanup
 rm ${RESULT_FILE}
+rm ${REQ_BODY_FILE}


### PR DESCRIPTION
- Add `pprof` http handlers. They are available in debug mode
- Update `scripts/bench.sh`. Attack API (`GET /api/months`) instead of a page (`/overview/{year}/{month}`)