### PR TITLE
Add a page to search for Spends

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ You can find screenshots of pages [here](./docs/images/README.md)
 - `/overview` - Overview Page (it is not ready yet)
 - `/overview/{year}` - Year Page
 - `/overview/{year}/{month_number}` - Month Page
+- `/search/spends` - Search for Spends
 
 ### API
 

--- a/internal/web/pages.go
+++ b/internal/web/pages.go
@@ -3,12 +3,14 @@ package web
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
 
 	"github.com/ShoshinNikita/budget-manager/internal/db"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/money"
+	"github.com/ShoshinNikita/budget-manager/internal/pkg/request_id"
 )
 
 const (
@@ -164,8 +166,112 @@ func (s Server) monthPage(w http.ResponseWriter, r *http.Request) {
 
 // GET /search/spends
 //
+// Query Params:
+//   - title - spend title
+//   - notes - spend notes
+//   - min_cost - minimal const
+//   - max_cost - maximal cost
+//   - after - date in format 'yyyy-mm-dd'
+//   - before - date in format 'yyyy-mm-dd'
+//
+// nolint:funlen
 func (s Server) searchSpendsPage(w http.ResponseWriter, r *http.Request) {
-	if err := s.tplStore.Execute(r.Context(), searchSpendsTemplatePath, w, nil); err != nil {
+	log := request_id.FromContextToLogger(r.Context(), s.log)
+
+	// Parse the query
+
+	// Parse Title and Notes
+	title := r.FormValue("title")
+	notes := r.FormValue("notes")
+
+	// Parse Min and Max Costs
+	minCost := func() money.Money {
+		minCostParam := r.FormValue("min_cost")
+		if minCostParam == "" {
+			return 0
+		}
+
+		minCost, err := strconv.ParseFloat(minCostParam, 64)
+		if err != nil {
+			// Just log this error
+			log.WithError(err).WithField("min_cost", minCostParam).Warn("couldn't parse 'min_cost' param")
+			return 0
+		}
+		return money.FromFloat(minCost)
+	}()
+	maxCost := func() money.Money {
+		maxCostParam := r.FormValue("max_cost")
+		if maxCostParam == "" {
+			return 0
+		}
+
+		maxCost, err := strconv.ParseFloat(maxCostParam, 64)
+		if err != nil {
+			// Just log this error
+			log.WithError(err).WithField("max_cost", maxCostParam).Warn("couldn't parse 'max_cost' param")
+			return 0
+		}
+		return money.FromFloat(maxCost)
+	}()
+
+	// Parse After and Before
+	const timeLayout = "2006-01-02"
+	after := func() time.Time {
+		after := r.FormValue("after")
+		if after == "" {
+			return time.Time{}
+		}
+
+		t, err := time.Parse(timeLayout, after)
+		if err != nil {
+			// Just log this error
+			log.WithError(err).WithField("after", after).Warn("couldn't parse 'after' param")
+			t = time.Time{}
+		}
+		return t
+	}()
+	before := func() time.Time {
+		before := r.FormValue("before")
+		if before == "" {
+			return time.Time{}
+		}
+
+		t, err := time.Parse(timeLayout, before)
+		if err != nil {
+			// Just log this error
+			log.WithError(err).WithField("before", before).Warn("couldn't parse 'before' param")
+			t = time.Time{}
+		}
+		return t
+	}()
+
+	// Process
+	args := db.SearchSpendsArgs{
+		Title:   strings.ToLower(title),
+		Notes:   strings.ToLower(notes),
+		After:   after,
+		Before:  before,
+		MinCost: minCost,
+		MaxCost: maxCost,
+		// TODO
+		TitleExactly: false,
+		NotesExactly: false,
+		TypeIDs:      []uint{},
+	}
+	spends, err := s.db.SearchSpends(r.Context(), args)
+	if err != nil {
+		msg, code, err := s.parseDBError(err)
+		s.processErrorWithPage(r.Context(), w, msg, code, err)
+		return
+	}
+
+	// Execute the template
+	resp := struct {
+		Spends []*db.Spend
+	}{
+		Spends: spends,
+	}
+	if err := s.tplStore.Execute(r.Context(), searchSpendsTemplatePath, w, resp); err != nil {
 		s.processErrorWithPage(r.Context(), w, executeErrorMessage, http.StatusInternalServerError, err)
 	}
 }

--- a/internal/web/pages.go
+++ b/internal/web/pages.go
@@ -12,9 +12,12 @@ import (
 )
 
 const (
-	overviewTemplatePath  = "./templates/overview.html"
-	yearTemplatePath      = "./templates/year.html"
-	monthTemplatePath     = "./templates/month.html"
+	overviewTemplatePath = "./templates/overview.html"
+	yearTemplatePath     = "./templates/year.html"
+	monthTemplatePath    = "./templates/month.html"
+	//
+	searchSpendsTemplatePath = "./templates/search_spends.html"
+	//
 	errorPageTemplatePath = "./templates/error_page.html"
 )
 
@@ -159,6 +162,18 @@ func (s Server) monthPage(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// GET /search/spends
+//
+func (s Server) searchSpendsPage(w http.ResponseWriter, r *http.Request) {
+	if err := s.tplStore.Execute(r.Context(), searchSpendsTemplatePath, w, nil); err != nil {
+		s.processErrorWithPage(r.Context(), w, executeErrorMessage, http.StatusInternalServerError, err)
+	}
+}
+
+// -------------------------------------------------
+// Helpers
+// -------------------------------------------------
+
 func toShortMonth(m time.Month) string {
 	month := m.String()
 	// Don't trim June and July
@@ -175,10 +190,6 @@ func sumSpendCosts(spends []*db.Spend) money.Money {
 	}
 	return m
 }
-
-// -------------------------------------------------
-// Helpers
-// -------------------------------------------------
 
 const yearKey = "year"
 

--- a/internal/web/pages.go
+++ b/internal/web/pages.go
@@ -293,9 +293,11 @@ func (s Server) searchSpendsPage(w http.ResponseWriter, r *http.Request) {
 	resp := struct {
 		Spends     []*db.Spend
 		SpendTypes []*db.SpendType
+		TotalCost  money.Money
 	}{
 		Spends:     spends,
 		SpendTypes: spendTypes,
+		TotalCost:  sumSpendCosts(spends),
 	}
 	if err := s.tplStore.Execute(r.Context(), searchSpendsTemplatePath, w, resp); err != nil {
 		s.processErrorWithPage(r.Context(), w, executeErrorMessage, http.StatusInternalServerError, err)

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -19,6 +19,7 @@ func (s Server) addRoutes(router *mux.Router) {
 		{methods: "GET", path: "/overview", handler: s.overviewPage},
 		{methods: "GET", path: "/overview/{year:[0-9]+}", handler: s.yearPage},
 		{methods: "GET", path: "/overview/{year:[0-9]+}/{month:[0-9]+}", handler: s.monthPage},
+		{methods: "GET", path: "/search/spends", handler: s.searchSpendsPage},
 		// 'GET /' redirects to the current month page
 		{methods: "GET", path: "/", handler: s.indexHandler},
 

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -60,6 +60,13 @@ div.feather-icon:hover > svg {
 
 /* | Inputs */
 
+input:focus,
+select:focus,
+textarea:focus,
+button:focus {
+	outline: none;
+}
+
 input {
 	background-color: white;
 	font-size: 15px;

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -17,6 +17,26 @@
 	font-weight: normal;
 }
 
+/* | Layout */
+
+body {
+	height: 100vh;
+	margin: 0;
+	padding: 30px;
+	padding-bottom: 40px;
+}
+
+#app {
+	border: 1px solid var(--border-color);
+	border-radius: 3px;
+	display: flex;
+	flex-direction: column;
+	margin: 0 auto 30px;
+	max-width: 1800px;
+	padding: 10px;
+	width: 100%;
+}
+
 /* | Icons */
 
 div.feather-icon {

--- a/templates/month.html
+++ b/templates/month.html
@@ -73,14 +73,17 @@
 			white-space: nowrap;
 		}
 
-		#header__type-manager {
+		#header__buttons {
+			column-gap: 5px;
+			display: grid;
+			grid-template-columns: repeat(2, 1fr);
 			height: 100%;
 			position: absolute;
 			right: 0px;
 			top: 0px;
 		}
 
-		#header__type-manager>svg {
+		#header__buttons svg {
 			height: 30px;
 			width: 30px;
 		}
@@ -355,8 +358,8 @@
 			}
 		}
 
-		/* For small screens (<= 900px) */
-		@media (max-width: 900px) {
+		/* For small screens (<= 950px) */
+		@media (max-width: 950px) {
 			#app {
 				height: auto;
 			}
@@ -458,10 +461,24 @@
 				</div>
 			</div>
 
-			<div id="header__type-manager" class="feather-icon" title="Manage Types" onclick="showModalWindowToEditTypes()">
-				<svg>
-					<use xlink:href="/static/feather/feather-sprite.svg#tag" />
-				</svg>
+			<div id="header__buttons">
+				<!-- Search for Spends -->
+				{{ $after := printf `%d-%02d-01` .Year .Month.Month }}
+				{{ $before := printf `%d-%02d-%d` .Year .Month.Month (len .Month.Days) }}
+				<a href="/search/spends?after={{ $after }}&before={{ $before }}">
+					<div class="feather-icon" title="Search for Spends">
+						<svg>
+							<use xlink:href="/static/feather/feather-sprite.svg#search" />
+						</svg>
+					</div>
+				</a>
+
+				<!-- Manage Spend Types -->
+				<div class="feather-icon" title="Manage Types" onclick="showModalWindowToEditTypes()">
+					<svg>
+						<use xlink:href="/static/feather/feather-sprite.svg#tag" />
+					</svg>
+				</div>
 			</div>
 		</div>
 

--- a/templates/month.html
+++ b/templates/month.html
@@ -11,13 +11,6 @@
 	<style>
 		/* | Global */
 
-		body {
-			height: 100vh;
-			margin: 0;
-			padding: 30px;
-			padding-bottom: 40px;
-		}
-
 		table th,
 		td {
 			word-break: keep-all;
@@ -47,15 +40,7 @@
 		/* | App */
 
 		#app {
-			border: 1px solid var(--border-color);
-			border-radius: 3px;
-			display: flex;
-			flex-direction: column;
 			height: 100%;
-			margin: 0 auto 30px;
-			max-width: 1800px;
-			padding: 10px;
-			width: 100%;
 		}
 
 		/* | Header */

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -156,6 +156,10 @@
 			white-space: nowrap;
 		}
 
+		.search__results__table__cost {
+			text-align: right;
+		}
+
 		.search__results__table__link {
 			z-index: 1;
 		}
@@ -163,6 +167,13 @@
 		.search__results__table__link div.feather-icon>svg {
 			height: 20px;
 			width: 20px;
+		}
+
+		#search__results__table__result-row .money--lose::after,
+		#search__results__table__result-row .money--gain::after {
+			/* Hide coin icon */
+			content: "";
+			margin-left: 0;
 		}
 
 		/* | Layouts */
@@ -269,7 +280,7 @@
 							<th class="search__results__table__title noselect">Title</th>
 							<th class="search__results__table__notes noselect">Notes</th>
 							<th class="search__results__table__type noselect">Type</th>
-							<th class="search__results__table__cost noselect">Cost</th>
+							<th class="search__results__table__cost noselect money">Cost,</th>
 							<th class="search__results__table__link noselect">Link</th>
 						</tr>
 					</thead>
@@ -298,6 +309,18 @@
 							</td>
 						</tr>
 						{{ end }}
+						<tr id="search__results__table__result-row">
+							<td colspan="4"></td>
+							<td class="search__results__table__cost" title="Total Cost">
+								<!-- Total Cost must be always <= 0 -->
+								{{ if eq .TotalCost 0 }}
+								<span class="money--gain">{{ .TotalCost }}</span>
+								{{ else }}
+								<span class="money--lose">{{ .TotalCost }}</span>
+								{{ end }}
+							</td>
+							<td></td>
+						</tr>
 					</tbody>
 				</table>
 			</div>

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Search | Budget Manager</title>
+
+	<link rel="stylesheet" href="/static/css/common.css">
+
+	<style>
+		/* | Global */
+
+		body {
+			min-width: 800px;
+		}
+
+		#app {
+			height: 100%;
+		}
+
+		input[type=date] {
+			border: none;
+			border-bottom: 1px solid var(--border-accent-color);
+			width: 100%;
+		}
+
+		/* | Search */
+
+		#search {
+			column-gap: 20px;
+			display: grid;
+			grid-template-columns: 1fr 4fr;
+			height: 100%;
+		}
+
+		#search__header {
+			border-bottom: 1px solid var(--border-accent-color);
+			font-size: 18px;
+			margin-bottom: 20px;
+			text-align: center;
+		}
+
+		/* || Search Options */
+
+		#search__options {
+			border: 1px solid var(--border-color);
+			border-radius: 3px;
+			height: 100%;
+			padding: 10px;
+		}
+
+		.search__option {
+			margin-bottom: 15px;
+		}
+
+		.search__option:last-child {
+			margin-bottom: 0;
+		}
+
+		#search__options__cost,
+		#search__options__time {
+			column-gap: 5px;
+			display: grid;
+			grid-template-columns: 1fr auto 1fr;
+		}
+
+		.search__options__separator::before {
+			content: "–";
+		}
+
+		#search__options__buttons {
+			column-gap: 20px;
+			display: grid;
+			grid-template-columns: repeat(2, min-content);
+			justify-content: center;
+		}
+
+		.search__options__button {
+			background-color: white;
+			border: none;
+		}
+
+		.search__options__button>.feather-icon>svg {
+			height: 25px;
+			width: 25px;
+		}
+
+		/* || Search Results */
+
+		#search__results {
+			height: 100%;
+		}
+
+		/* | Layouts */
+
+		/* For medium screens (<= 1300px) */
+		@media (max-width: 1300px) {
+
+			#search__options__cost,
+			#search__options__time {
+				grid-template-columns: 1fr;
+				grid-template-rows: 1fr 1fr;
+				row-gap: 10px;
+			}
+
+			.search__options__separator {
+				display: none;
+			}
+		}
+	</style>
+</head>
+
+<body>
+	<div id="app">
+		<div id="search">
+			<!-- Search Options -->
+			<div id="search__options">
+				<div id="search__header" class="noselect">Spend Search</div>
+
+				<form action="/search/spends">
+
+					<!-- Title -->
+					<div id="search__options__title" class="search__option">
+						<input type="text" name="title" placeholder="Title">
+					</div>
+
+					<!-- Notes -->
+					<div id="search__options__notes" class="search__option">
+						<input type="text" name="notes" placeholder="Notes">
+					</div>
+
+					<!-- Cost -->
+					<div id="search__options__cost" class="search__option">
+						<div id="search__options__cost__min">
+							<input type="text" name="min_cost" placeholder="Min Cost">
+						</div>
+
+						<div class="search__options__separator"></div>
+
+						<div id="search__options__cost__max">
+							<input type="text" name="max_cost" placeholder="Max Cost">
+						</div>
+					</div>
+
+					<!-- Time -->
+					<div id="search__options__time" class="search__option">
+						<div id="search__options__time__after">
+							<input type="date" name="after" title="After">
+						</div>
+
+						<div class="search__options__separator"></div>
+
+						<div id="search__options__time__before">
+							<input type="date" name="before" title="Before">
+						</div>
+					</div>
+
+					<!-- Buttons -->
+					<div id="search__options__buttons">
+						<button type="reset" class="search__options__button" title="Reset">
+							<div class="feather-icon">
+								<svg>
+									<use xlink:href="/static/feather/feather-sprite.svg#rotate-ccw" /> </svg>
+							</div>
+						</button>
+
+						<button type="submit" class="search__options__button" title="Search">
+							<div class="feather-icon">
+								<svg>
+									<use xlink:href="/static/feather/feather-sprite.svg#search" /> </svg>
+							</div>
+						</button>
+					</div>
+
+				</form>
+			</div>
+
+			<!-- Search Results -->
+			<div id="search__results"> </div>
+		</div>
+	</div>
+</body>
+
+</html>

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -70,6 +70,26 @@
 			color: #4d4d4d;
 		}
 
+		#search__options__types {
+			margin-left: auto;
+			margin-right: auto;
+			min-width: 60%;
+			width: min-content;
+		}
+
+		#search__options__types__header {
+			border-bottom: 1px solid var(--border-color);
+			margin: 0 auto 7px;
+			padding: 0 10px;
+			text-align: center;
+			width: min-content;
+			white-space: nowrap;
+		}
+
+		.search__options__types__type {
+			white-space: nowrap;
+		}
+
 		#search__options__buttons {
 			column-gap: 20px;
 			display: grid;
@@ -209,6 +229,17 @@
 						</div>
 					</div>
 
+					<!-- Spend Types -->
+					<div id="search__options__types" class="search__option">
+						<div id="search__options__types__header" class="noselect">Spend Types</div>
+						{{ range .SpendTypes }}
+						<div class="search__options__types__type">
+							<input id="search__options__types__type-{{ .ID }}" type="checkbox" name="type_id" value="{{ .ID }}">
+							<label for="search__options__types__type-{{ .ID }}">{{ .Name }}</label>
+						</div>
+						{{ end }}
+					</div>
+
 					<!-- Buttons -->
 					<div id="search__options__buttons">
 						<button type="reset" class="search__options__button" title="Reset">
@@ -301,6 +332,18 @@
 			// Before
 			const before = query.get("before");
 			setOptionValue("search__options__time__before", before);
+
+			// Spend Types
+			const typeIDs = query.getAll("type_id");
+			for (let i = 0; i < typeIDs.length; i++) {
+				const elemID = "search__options__types__type-" + typeIDs[i];
+				const checkbox = document.getElementById(elemID);
+				if (!checkbox) {
+					console.error(`element '${elemID}' doesn't exist`);
+					continue;
+				}
+				checkbox.checked = true;
+			}
 		})
 
 		/**

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -329,6 +329,25 @@
 			const elem = parent.children[0];
 			elem.value = value;
 		}
+
+		// Set date titles
+		window.addEventListener("load", () => {
+			let cache = {};
+
+			const dateFormatOptions = { weekday: "long", year: "numeric", month: "long", day: "numeric" };
+			const dates = document.querySelectorAll("td.search__results__table__date");
+			for (let i = 0; i < dates.length; i++) {
+				const originalDate = dates[i].textContent;
+				let date = cache[originalDate];
+				if (!date) {
+					// Remove thin spaces and format like 'Friday, November 1, 2019'
+					date = new Date(originalDate.replace(/ /g, "", -1)).toLocaleDateString("en-US", dateFormatOptions);
+					cache[originalDate] = date;
+				}
+
+				dates[i].title = date;
+			}
+		})
 	</script>
 </body>
 

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -67,6 +67,7 @@
 
 		.search__options__separator::before {
 			content: "–";
+			color: #4d4d4d;
 		}
 
 		#search__options__buttons {
@@ -122,24 +123,24 @@
 
 					<!-- Title -->
 					<div id="search__options__title" class="search__option">
-						<input type="text" name="title" placeholder="Title">
+						<input type="text" name="title" placeholder="Title" title="Title">
 					</div>
 
 					<!-- Notes -->
 					<div id="search__options__notes" class="search__option">
-						<input type="text" name="notes" placeholder="Notes">
+						<input type="text" name="notes" placeholder="Notes" title="Notes">
 					</div>
 
 					<!-- Cost -->
 					<div id="search__options__cost" class="search__option">
 						<div id="search__options__cost__min">
-							<input type="text" name="min_cost" placeholder="Min Cost">
+							<input type="text" name="min_cost" placeholder="Min Cost" title="Minimal Cost">
 						</div>
 
 						<div class="search__options__separator"></div>
 
 						<div id="search__options__cost__max">
-							<input type="text" name="max_cost" placeholder="Max Cost">
+							<input type="text" name="max_cost" placeholder="Max Cost" title="Maximal Cost">
 						</div>
 					</div>
 
@@ -180,6 +181,64 @@
 			<div id="search__results"> </div>
 		</div>
 	</div>
+
+	<script>
+		// Update Search Options with query params
+		window.addEventListener("load", () => {
+			const query = new URLSearchParams(location.search);
+
+			// Title
+			const title = query.get("title");
+			setOptionValue("search__options__title", title);
+
+			// Notes
+			const notes = query.get("notes");
+			setOptionValue("search__options__notes", notes);
+
+			// Min Cost
+			const minCost = query.get("min_cost");
+			setOptionValue("search__options__cost__min", minCost);
+
+			// Max cost
+			const maxCost = query.get("max_cost");
+			setOptionValue("search__options__cost__max", maxCost);
+
+			// After
+			const after = query.get("after");
+			setOptionValue("search__options__time__after", after);
+
+			// Before
+			const before = query.get("before");
+			setOptionValue("search__options__time__before", before);
+		})
+
+		/**
+		* @param {string} parentID - id of an input parent
+		* @param {string} value - new value
+		*/
+		function setOptionValue(parentID, value) {
+			if (value === "") {
+				return;
+			}
+
+			const parent = document.getElementById(parentID);
+			if (parent === undefined) {
+				console.error(`element '${parentID}' doesn't exist`);
+				return;
+			}
+			if (parent.childElementCount < 1) {
+				console.error(`element '${parentID}' doesn't have any children`);
+				return;
+			}
+			if (parent.children[0].tagName !== "INPUT") {
+				console.error(`the first child of element '${parentID}' must be <input>`);
+				return;
+			}
+
+			const elem = parent.children[0];
+			elem.value = value;
+		}
+	</script>
 </body>
 
 </html>

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -96,6 +96,55 @@
 			overflow-y: auto;
 		}
 
+		#search__results__table {
+			/*
+				We have to overwrite property 'border-collapse' because it doesn't work properly with 'position: sticky':
+				https://stackoverflow.com/a/53559396/7752659
+			*/
+			border-collapse: separate;
+			border-spacing: 0;
+		}
+
+		#search__results__table th {
+			background-color: white;
+			border-bottom: 1px solid var(--border-accent-color);
+			font-size: 18px;
+			position: sticky;
+			top: 0;
+		}
+
+		#search__results__table th,
+		#search__results__table td {
+			padding-right: 10px;
+			padding-left: 10px;
+		}
+
+		#search__results__table th:first-child,
+		#search__results__table td:first-child {
+			padding-left: 5px;
+		}
+
+		#search__results__table th:last-child,
+		#search__results__table td:last-child {
+			padding-right: 5px;
+		}
+
+		.search__results__table__date,
+		.search__results__table__type,
+		.search__results__table__cost,
+		.search__results__table__link {
+			white-space: nowrap;
+		}
+
+		.search__results__table__link {
+			z-index: 1;
+		}
+
+		.search__results__table__link div.feather-icon>svg {
+			height: 20px;
+			width: 20px;
+		}
+
 		/* | Layouts */
 
 		/* For medium screens (<= 1300px) */
@@ -182,10 +231,44 @@
 
 			<!-- Search Results -->
 			<div id="search__results">
-				{{range .Spends}}
-				{{.}}
-				<br>
-				{{end}}
+				<table id="search__results__table">
+					<thead>
+						<tr>
+							<th class="search__results__table__date noselect">Date</th>
+							<th class="search__results__table__title noselect">Title</th>
+							<th class="search__results__table__notes noselect">Notes</th>
+							<th class="search__results__table__type noselect">Type</th>
+							<th class="search__results__table__cost noselect">Cost</th>
+							<th class="search__results__table__link noselect">Link</th>
+						</tr>
+					</thead>
+					<tbody>
+						{{ range .Spends }}
+						<tr>
+							<td class="search__results__table__date">{{ printf "%02d" .Month }} / {{ printf "%02d" .Day }} / {{ .Year }}</td>
+							<td class="search__results__table__title">{{ .Title }}</td>
+							<td class="search__results__table__notes">{{ .Notes }}</td>
+							<td class="search__results__table__type">
+								{{ if .Type }}
+								<span>{{ .Type.Name }}</span>
+								{{ else }}
+								<span>-</span>
+								{{ end }}
+							</td>
+							<td class="search__results__table__cost">{{ .Cost }}</td>
+							<td class="search__results__table__link">
+								<a href="/overview/{{ .Year }}/{{ printf `%d` .Month }}#{{ .Day }}">
+									<div class="feather-icon" title="View Day">
+										<svg>
+											<use xlink:href="/static/feather/feather-sprite.svg#external-link" />
+										</svg>
+									</div>
+								</a>
+							</td>
+						</tr>
+						{{ end }}
+					</tbody>
+				</table>
 			</div>
 		</div>
 	</div>

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -135,8 +135,8 @@
 
 		#search__results__table th,
 		#search__results__table td {
-			padding-right: 10px;
-			padding-left: 10px;
+			padding-right: 15px;
+			padding-left: 15px;
 		}
 
 		#search__results__table th:first-child,
@@ -153,7 +153,12 @@
 		.search__results__table__type,
 		.search__results__table__cost,
 		.search__results__table__link {
+			width: 1px;
 			white-space: nowrap;
+		}
+
+		#search__results__table td.search__results__table__cost {
+			padding-right: 20px;
 		}
 
 		.search__results__table__cost {
@@ -161,6 +166,7 @@
 		}
 
 		.search__results__table__link {
+			text-align: center;
 			z-index: 1;
 		}
 

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -80,6 +80,8 @@
 		.search__options__button {
 			background-color: white;
 			border: none;
+			margin: 0px;
+			padding: 0px;
 		}
 
 		.search__options__button>.feather-icon>svg {
@@ -91,6 +93,7 @@
 
 		#search__results {
 			height: 100%;
+			overflow-y: auto;
 		}
 
 		/* | Layouts */
@@ -178,7 +181,12 @@
 			</div>
 
 			<!-- Search Results -->
-			<div id="search__results"> </div>
+			<div id="search__results">
+				{{range .Spends}}
+				{{.}}
+				<br>
+				{{end}}
+			</div>
 		</div>
 	</div>
 

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -218,6 +218,11 @@
 			.search__options__separator {
 				display: none;
 			}
+
+			/* Hide notes */
+			.search__results__table__notes {
+				display: none;
+			}
 		}
 	</style>
 </head>
@@ -346,7 +351,12 @@
 						</tr>
 						{{ end }}
 						<tr id="search__results__table__result-row">
-							<td colspan="4"></td>
+							<!--
+								We can't use colspan="4" because we hide notes with 'display: none' for small and
+								medium screens. With colspan="4" there will be some bugs
+							 -->
+							<td colspan="3"></td>
+							<td class="search__results__table__notes"></td>
 							<td class="search__results__table__cost" title="Total Cost">
 								<!-- Total Cost must be always <= 0 -->
 								{{ if eq .TotalCost 0 }}

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -34,12 +34,6 @@
 			height: 100%;
 		}
 
-		#search__header {
-			border-bottom: 1px solid var(--border-accent-color);
-			font-size: 18px;
-			margin-bottom: 20px;
-			text-align: center;
-		}
 
 		/* || Search Options */
 
@@ -48,6 +42,14 @@
 			border-radius: 3px;
 			height: 100%;
 			padding: 10px;
+			position: relative;
+		}
+
+		#search__options__header {
+			border-bottom: 1px solid var(--border-accent-color);
+			font-size: 18px;
+			margin-bottom: 20px;
+			text-align: center;
 		}
 
 		.search__option {
@@ -108,6 +110,19 @@
 			height: 25px;
 			width: 25px;
 		}
+
+		#search__options__home-page-link {
+			bottom: 5px;
+			left: 50%;
+			position: absolute;
+			transform: translateX(-50%);
+		}
+
+		#search__options__home-page-link svg {
+			height: 25px;
+			width: 25px;
+		}
+
 
 		/* || Search Results */
 
@@ -206,10 +221,9 @@
 		<div id="search">
 			<!-- Search Options -->
 			<div id="search__options">
-				<div id="search__header" class="noselect">Spend Search</div>
+				<div id="search__options__header" class="noselect">Spend Search</div>
 
 				<form action="/search/spends">
-
 					<!-- Title -->
 					<div id="search__options__title" class="search__option">
 						<input type="text" name="title" placeholder="Title" title="Title">
@@ -273,8 +287,17 @@
 							</div>
 						</button>
 					</div>
-
 				</form>
+
+				<div id="search__options__home-page-link">
+					<a href="/">
+						<div class="feather-icon" title="Home">
+							<svg>
+								<use xlink:href="/static/feather/feather-sprite.svg#home" />
+							</svg>
+						</div>
+					</a>
+				</div>
 			</div>
 
 			<!-- Search Results -->

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -197,6 +197,12 @@
 			margin-left: 0;
 		}
 
+		#search__results__no-spends {
+			font-size: 20px;
+			margin-top: 25px;
+			text-align: center;
+		}
+
 		/* | Layouts */
 
 		/* For medium screens (<= 1300px) */
@@ -302,6 +308,7 @@
 
 			<!-- Search Results -->
 			<div id="search__results">
+				{{ if .Spends }}
 				<table id="search__results__table">
 					<thead>
 						<tr>
@@ -352,6 +359,11 @@
 						</tr>
 					</tbody>
 				</table>
+				{{ else }}
+				<div id="search__results__no-spends" class="noselect">
+					<span>No Spends found!</span>
+				</div>
+				{{ end }}
 			</div>
 		</div>
 	</div>

--- a/templates/year.html
+++ b/templates/year.html
@@ -8,13 +8,6 @@
 	<link rel="stylesheet" href="/static/css/common.css">
 
 	<style>
-		body {
-			height: 100vh;
-			margin: 0;
-			padding: 30px;
-			padding-bottom: 40px;
-		}
-
 		a:link.no-decoration {
 			text-decoration: none !important;
 		}
@@ -22,15 +15,7 @@
 		/* | App */
 
 		#app {
-			border: 1px solid var(--border-color);
-			border-radius: 3px;
-			display: flex;
-			flex-direction: column;
-			margin: 0 auto 30px;
-			max-width: 1800px;
 			min-height: 100%;
-			padding: 10px;
-			width: 100%;
 		}
 
 		/* || Header */


### PR DESCRIPTION
This PR relates to the issue #78

- Add `templates/search_spends.html`:

    - we use `<form>` to pass search options
    - `<form>` doesn't support `title_exactly` and `notes_exactly` yet

- Update `templates/month.html`:
    - add a button to search for spends in a current month
