### PR TITLE
Add an opportunity to search for Spends without a type

### DIFF
--- a/internal/db/args.go
+++ b/internal/db/args.go
@@ -70,6 +70,8 @@ type EditSpendArgs struct {
 // ----------------------------------------------------
 
 // SearchSpendsArgs is used to search for spends. All fields are optional
+//
+// nolint:maligned
 type SearchSpendsArgs struct {
 	Title string // Must be in lovercase
 	Notes string // Must be in lovercase

--- a/internal/db/args.go
+++ b/internal/db/args.go
@@ -85,5 +85,7 @@ type SearchSpendsArgs struct {
 	MinCost money.Money
 	MaxCost money.Money
 
-	TypeIDs []uint
+	// WithoutType is used to search for Spends without Spend Type. TypeIDs must be ignored when it is true
+	WithoutType bool
+	TypeIDs     []uint
 }

--- a/internal/db/pg/search.go
+++ b/internal/db/pg/search.go
@@ -158,7 +158,10 @@ func (DB) buildSearchSpendsQuery(tx *pg.Tx, args db_common.SearchSpendsArgs) *or
 		query = query.Where("spend.cost <= ?", args.MaxCost)
 	}
 
-	if len(args.TypeIDs) != 0 {
+	switch {
+	case args.WithoutType:
+		query = query.Where("spend.type_id IS NULL")
+	case len(args.TypeIDs) != 0:
 		query = query.WhereIn("spend.type_id IN (?)", args.TypeIDs)
 	}
 

--- a/internal/db/pg/search_test.go
+++ b/internal/db/pg/search_test.go
@@ -284,6 +284,43 @@ func TestSearchSpends(t *testing.T) {
 			},
 			want: []*db_common.Spend{},
 		},
+		{
+			desc: "search for spends without type",
+			args: db_common.SearchSpendsArgs{
+				WithoutType: true,
+			},
+			want: []*db_common.Spend{
+				{ID: 2, Year: 2019, Month: time.December, Day: 5, Title: "first spend", Notes: "2019-12-05", Cost: FromInt(10)},
+				{ID: 3, Year: 2019, Month: time.December, Day: 8, Title: "first spend", Notes: "2019-12-08", Cost: FromInt(159)},
+				{ID: 4, Year: 2019, Month: time.December, Day: 8, Title: "second spend", Notes: "2019-12-08", Cost: FromInt(15)},
+				{ID: 6, Year: 2020, Month: time.January, Day: 1, Title: "second spend", Notes: "2020-01-01", Cost: FromInt(7821)},
+				{ID: 7, Year: 2020, Month: time.January, Day: 10, Title: "first spend", Notes: "2020-01-10", Cost: FromInt(555)},
+				{ID: 8, Year: 2020, Month: time.January, Day: 30, Title: "second spend", Notes: "2020-01-30", Cost: FromInt(15)},
+				{ID: 9, Year: 2020, Month: time.February, Day: 8, Title: "first spend", Notes: "2020-02-08", Cost: FromInt(189)},
+				{ID: 10, Year: 2020, Month: time.February, Day: 13, Title: "qwerty", Notes: "2020-02-13", Cost: FromInt(7821)},
+				{ID: 11, Year: 2020, Month: time.February, Day: 14, Title: "first spending", Notes: "2020-02-14", Cost: FromInt(555)},
+				{ID: 12, Year: 2020, Month: time.February, Day: 15, Title: "TITLE", Notes: "NOTES", Cost: FromInt(1)},
+			},
+		},
+		{
+			desc: "search for spends without type (pass type ids)",
+			args: db_common.SearchSpendsArgs{
+				WithoutType: true,
+				TypeIDs:     []uint{1, 2, 3},
+			},
+			want: []*db_common.Spend{
+				{ID: 2, Year: 2019, Month: time.December, Day: 5, Title: "first spend", Notes: "2019-12-05", Cost: FromInt(10)},
+				{ID: 3, Year: 2019, Month: time.December, Day: 8, Title: "first spend", Notes: "2019-12-08", Cost: FromInt(159)},
+				{ID: 4, Year: 2019, Month: time.December, Day: 8, Title: "second spend", Notes: "2019-12-08", Cost: FromInt(15)},
+				{ID: 6, Year: 2020, Month: time.January, Day: 1, Title: "second spend", Notes: "2020-01-01", Cost: FromInt(7821)},
+				{ID: 7, Year: 2020, Month: time.January, Day: 10, Title: "first spend", Notes: "2020-01-10", Cost: FromInt(555)},
+				{ID: 8, Year: 2020, Month: time.January, Day: 30, Title: "second spend", Notes: "2020-01-30", Cost: FromInt(15)},
+				{ID: 9, Year: 2020, Month: time.February, Day: 8, Title: "first spend", Notes: "2020-02-08", Cost: FromInt(189)},
+				{ID: 10, Year: 2020, Month: time.February, Day: 13, Title: "qwerty", Notes: "2020-02-13", Cost: FromInt(7821)},
+				{ID: 11, Year: 2020, Month: time.February, Day: 14, Title: "first spending", Notes: "2020-02-14", Cost: FromInt(555)},
+				{ID: 12, Year: 2020, Month: time.February, Day: 15, Title: "TITLE", Notes: "NOTES", Cost: FromInt(1)},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/internal/db/pg/search_unit_test.go
+++ b/internal/db/pg/search_unit_test.go
@@ -153,6 +153,21 @@ func TestBuildSearchSpendsQuery(t *testing.T) {
 			},
 		},
 		{
+			desc:     "without type",
+			reqQuery: buildWhereQuery(`WHERE (spend.type_id IS NULL)`),
+			args: db_common.SearchSpendsArgs{
+				WithoutType: true,
+			},
+		},
+		{
+			desc:     "without type (pass type ids)",
+			reqQuery: buildWhereQuery(`WHERE (spend.type_id IS NULL)`),
+			args: db_common.SearchSpendsArgs{
+				WithoutType: true,
+				TypeIDs:     []uint{1, 2, 5, 25, 3},
+			},
+		},
+		{
 			desc: "all args",
 			reqQuery: buildWhereQuery(`
 				WHERE (LOWER(spend.title) LIKE '%123%')

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -974,7 +974,10 @@ func (s Server) SearchSpends(w http.ResponseWriter, r *http.Request) {
 		Before:       req.Before,
 		MinCost:      money.FromFloat(req.MinCost),
 		MaxCost:      money.FromFloat(req.MaxCost),
-		TypeIDs:      req.TypeIDs,
+		WithoutType:  req.WithoutType,
+	}
+	if !args.WithoutType {
+		args.TypeIDs = req.TypeIDs
 	}
 	spends, err := s.db.SearchSpends(r.Context(), args)
 	if err != nil {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -964,7 +964,7 @@ func (s Server) SearchSpends(w http.ResponseWriter, r *http.Request) {
 	})
 
 	// Process
-	log.Debug("search Spends")
+	log.Debug("search for Spends")
 	args := db.SearchSpendsArgs{
 		Title:        strings.ToLower(req.Title),
 		Notes:        strings.ToLower(req.Notes),

--- a/internal/web/handlers_unit_test.go
+++ b/internal/web/handlers_unit_test.go
@@ -81,6 +81,26 @@ func TestSearchSpends(t *testing.T) {
 			},
 		},
 		{
+			desc: "pass without type",
+			//
+			req: models.SearchSpendsReq{
+				WithoutType: true,
+				TypeIDs:     []uint{1, 2, 3},
+			},
+			expect: func(m *MockDatabase) {
+				args := db.SearchSpendsArgs{
+					WithoutType: true,
+				}
+				m.On("SearchSpends", mock.Anything, args).Return([]*db.Spend{}, nil)
+			},
+			//
+			statusCode: 200,
+			resp: models.SearchSpendsResp{
+				Response: models.Response{RequestID: "request-id", Success: true},
+				Spends:   []*db.Spend{},
+			},
+		},
+		{
 			desc: "db error",
 			//
 			expect: func(m *MockDatabase) {

--- a/internal/web/models/models.go
+++ b/internal/web/models/models.go
@@ -301,6 +301,8 @@ type RemoveSpendTypeReq struct {
 // -------------------------------------------------
 
 // SearchSpendsReq is used to search for spends, all fields are optional
+//
+// nolint:maligned
 type SearchSpendsReq struct {
 	Request
 

--- a/internal/web/models/models.go
+++ b/internal/web/models/models.go
@@ -322,6 +322,8 @@ type SearchSpendsReq struct {
 	MinCost float64 `json:"min_cost,omitempty"`
 	MaxCost float64 `json:"max_cost,omitempty"`
 
+	// WithoutType is used to search for Spends without Spend Type. TypeIDs are ignored when it is true
+	WithoutType bool `json:"without_type,omitempty"`
 	// TypeIDs is a list of Spend Type ids to search for
 	TypeIDs []uint `json:"type_ids,omitempty"`
 }

--- a/internal/web/pages.go
+++ b/internal/web/pages.go
@@ -184,6 +184,7 @@ func (s Server) monthPage(w http.ResponseWriter, r *http.Request) {
 //   - max_cost - maximal cost
 //   - after - date in format 'yyyy-mm-dd'
 //   - before - date in format 'yyyy-mm-dd'
+//   - without_type - option to search for Spends without Spend Type (all passed type ids will be ignored)
 //   - type_id - Spend Type id to search (can be passed multiple times: ?type_id=56&type_id=58)
 //
 // nolint:funlen
@@ -257,10 +258,12 @@ func (s Server) searchSpendsPage(w http.ResponseWriter, r *http.Request) {
 		return t
 	}()
 
-	// Parse Spend Type ids
-	typeIDs := func() []uint {
+	withoutType := r.FormValue("without_type") == "true"
+
+	// Parse Spend Type ids if needed
+	var typeIDs []uint
+	if !withoutType {
 		ids := r.Form["type_id"]
-		typeIDs := make([]uint, 0, len(ids))
 		for i := range ids {
 			id, err := strconv.ParseUint(ids[i], 10, 0)
 			if err != nil {
@@ -270,18 +273,18 @@ func (s Server) searchSpendsPage(w http.ResponseWriter, r *http.Request) {
 			}
 			typeIDs = append(typeIDs, uint(id))
 		}
-		return typeIDs
-	}()
+	}
 
 	// Process
 	args := db.SearchSpendsArgs{
-		Title:   strings.ToLower(title),
-		Notes:   strings.ToLower(notes),
-		After:   after,
-		Before:  before,
-		MinCost: minCost,
-		MaxCost: maxCost,
-		TypeIDs: typeIDs,
+		Title:       strings.ToLower(title),
+		Notes:       strings.ToLower(notes),
+		After:       after,
+		Before:      before,
+		MinCost:     minCost,
+		MaxCost:     maxCost,
+		WithoutType: withoutType,
+		TypeIDs:     typeIDs,
 		// TODO
 		TitleExactly: false,
 		NotesExactly: false,

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -274,9 +274,14 @@
 					<!-- Spend Types -->
 					<div id="search__options__types" class="search__option">
 						<div id="search__options__types__header" class="noselect">Spend Types</div>
+						<!-- Without Type option -->
+						<div class="search__options__types__type">
+							<input id="search__options__types__without-type" type="checkbox" name="without_type" value="true" onclick="resetChosenTypes()">
+							<label for="search__options__types__without-type" title="Use this option to search for Spends without type">Without Type</label>
+						</div>
 						{{ range .SpendTypes }}
 						<div class="search__options__types__type">
-							<input id="search__options__types__type-{{ .ID }}" type="checkbox" name="type_id" value="{{ .ID }}">
+							<input id="search__options__types__type-{{ .ID }}" type="checkbox" name="type_id" value="{{ .ID }}" onclick="resetWithoutType()">
 							<label for="search__options__types__type-{{ .ID }}">{{ .Name }}</label>
 						</div>
 						{{ end }}
@@ -407,6 +412,17 @@
 			const before = query.get("before");
 			setOptionValue("search__options__time__before", before);
 
+			// Without Type
+			const withoutType = query.get("without_type");
+			if (withoutType == "true") {
+				const checkbox = document.getElementById("search__options__types__without-type");
+				if (!checkbox) {
+					console.error(`element '${elemID}' doesn't exist`);
+				} else {
+					checkbox.checked = true;
+				}
+			}
+
 			// Spend Types
 			const typeIDs = query.getAll("type_id");
 			for (let i = 0; i < typeIDs.length; i++) {
@@ -465,6 +481,31 @@
 				dates[i].title = date;
 			}
 		})
+
+		/**
+		 * Set all Spend Types to false
+		 */
+		function resetChosenTypes() {
+			const inputs = document.getElementsByTagName("input");
+			for (let i = 0; i < inputs.length; i++) {
+				if (inputs[i].id.indexOf("search__options__types__type-") == 0) {
+					inputs[i].checked = false;
+				}
+			}
+		}
+
+		/**
+		 * Set Without Type option to false
+		 */
+		function resetWithoutType() {
+			const elemID = "search__options__types__without-type";
+			const input = document.getElementById(elemID);
+			if (!input) {
+				console.error(`element '${elemID}' doesn't exist`);
+				return;
+			}
+			input.checked = false;
+		}
 	</script>
 </body>
 


### PR DESCRIPTION
This PR relates to the issue #78 

Add an option `without_type` to search for Spends without a type