### PR TITLE
Update golangci-lint, refactor workflow

### DIFF
--- a/.github/workflows/check_code.yml
+++ b/.github/workflows/check_code.yml
@@ -1,33 +1,34 @@
-name: Check code
+name: check code
 on:
   push:
     paths-ignore:
-      - "templates/**"
+      - "docs/**"
+      - "scripts/**"
       - "static/**"
+      - "templates/**"
       - "tools/**"
       - "README.md"
 
 jobs:
-  check-code:
-    name: Check code
+  test:
+    name: run tests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.13
-        id: go
+          go-version: 1.14
 
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Install golangci-lint
-        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ${GITHUB_WORKSPACE} v1.23.8
-
-      - name: Lint
-        run: |
-          PATH="${PATH}:${GITHUB_WORKSPACE}"
-          make lint
+      - uses: actions/checkout@v2
 
       - name: Run integration tests
         run: make test-integ
+
+  lint:
+    name: lint code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.27

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,10 +8,12 @@ linters:
   enable-all: true
   disable:
     - dupl
+    - godot
     - godox
+    - gomnd
+    - testpackage
     - whitespace
     - wsl
-    - gomnd
 
 linters-settings:
   funlen:
@@ -25,6 +27,11 @@ issues:
     - "use underscores in Go names; (?:func|type) (?:T|t)est"
     # Ignore long functions in tests
     - "Function '(?:T|t)est.*' is too long"
+
+  exclude-rules:
+    - linters:
+        - goerr113
+      text: "do not define dynamic errors"
 
   # Display all issues
   max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,10 @@ export-ldflags:
 lint:
 	# golangci-lint - https://github.com/golangci/golangci-lint
 	#
-	golangci-lint run --config .golangci.yml
+	docker run --rm -it --network=none \
+		-v $(shell pwd):/app \
+		-w /app \
+		golangci/golangci-lint:v1.23.8-alpine golangci-lint run --config .golangci.yml
 
 check: build lint test
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ lint:
 	docker run --rm -it --network=none \
 		-v $(shell pwd):/app \
 		-w /app \
-		golangci/golangci-lint:v1.23.8-alpine golangci-lint run --config .golangci.yml
+		golangci/golangci-lint:v1.27.0-alpine golangci-lint run --config .golangci.yml
 
 check: build lint test
 

--- a/internal/db/pg/common.go
+++ b/internal/db/pg/common.go
@@ -31,7 +31,7 @@ func (db DB) GetMonth(ctx context.Context, id uint) (month *db_common.Month, err
 		return nil
 	})
 	if err != nil {
-		if err == pg.ErrNoRows {
+		if errors.Is(err, pg.ErrNoRows) {
 			err = db_common.ErrMonthNotExist
 			log.Error(err)
 			return nil, err
@@ -53,7 +53,7 @@ func (db DB) GetMonthID(ctx context.Context, year, month int) (uint, error) {
 	m := &Month{}
 	err := db.db.Model(m).Column("id").Where("year = ? AND month = ?", year, month).Select()
 	if err != nil {
-		if err == pg.ErrNoRows {
+		if errors.Is(err, pg.ErrNoRows) {
 			err = db_common.ErrMonthNotExist
 			log.Error(err)
 			return 0, err
@@ -73,7 +73,7 @@ func (DB) getMonthIDByDayID(_ context.Context, tx *pg.Tx, dayID uint) (uint, err
 	day := &Day{ID: dayID}
 	err := tx.Model(day).Column("month_id").WherePK().Select()
 	if err != nil {
-		if err == pg.ErrNoRows {
+		if errors.Is(err, pg.ErrNoRows) {
 			return 0, db_common.ErrDayNotExist
 		}
 
@@ -134,7 +134,7 @@ func (db DB) GetDay(ctx context.Context, id uint) (*db_common.Day, error) {
 			Relation("Spends.Type").
 			WherePK().Select()
 		if err != nil {
-			if err == pg.ErrNoRows {
+			if errors.Is(err, pg.ErrNoRows) {
 				return db_common.ErrDayNotExist
 			}
 			return err
@@ -166,7 +166,7 @@ func (db DB) GetDayIDByDate(ctx context.Context, year int, month int, day int) (
 
 	monthID, err := db.GetMonthID(ctx, year, month)
 	if err != nil {
-		if err == db_common.ErrMonthNotExist {
+		if errors.Is(err, db_common.ErrMonthNotExist) {
 			err = db_common.ErrMonthNotExist
 			log.Error(err)
 			return 0, err
@@ -184,7 +184,7 @@ func (db DB) GetDayIDByDate(ctx context.Context, year int, month int, day int) (
 		Where("month_id = ? AND day = ?", monthID, day).
 		Select()
 	if err != nil {
-		if err == pg.ErrNoRows {
+		if errors.Is(err, pg.ErrNoRows) {
 			err = db_common.ErrDayNotExist
 			log.Error(err)
 			return 0, err

--- a/internal/db/pg/common.go
+++ b/internal/db/pg/common.go
@@ -203,7 +203,6 @@ func (db DB) GetDayIDByDate(ctx context.Context, year int, month int, day int) (
 // Internal methods
 // -----------------------------------------------------------------------------
 
-// nolint:funlen
 func (db DB) recomputeMonth(tx *pg.Tx, monthID uint) error {
 	m, err := db.getMonth(tx, monthID)
 	if err != nil {

--- a/internal/db/pg/income.go
+++ b/internal/db/pg/income.go
@@ -81,7 +81,7 @@ func (db DB) EditIncome(ctx context.Context, args db_common.EditIncomeArgs) erro
 		// Select Income
 		err = tx.Select(in)
 		if err != nil {
-			if err == pg.ErrNoRows {
+			if errors.Is(err, pg.ErrNoRows) {
 				return db_common.ErrIncomeNotExist
 			}
 			return errors.Wrap(err, "couldn't select Income")

--- a/internal/db/pg/monthly_payment.go
+++ b/internal/db/pg/monthly_payment.go
@@ -78,7 +78,7 @@ func (db DB) EditMonthlyPayment(ctx context.Context, args db_common.EditMonthlyP
 	err := db.db.RunInTransaction(func(tx *pg.Tx) (err error) {
 		err = tx.Select(mp)
 		if err != nil {
-			if err == pg.ErrNoRows {
+			if errors.Is(err, pg.ErrNoRows) {
 				return db_common.ErrMonthlyPaymentNotExist
 			}
 			return errors.Wrap(err, "couldn't get Monthly Payment with passed id")

--- a/internal/db/pg/pg.go
+++ b/internal/db/pg/pg.go
@@ -288,7 +288,7 @@ func (db *DB) addMonth(year int, month time.Month) error {
 		// The month is already created
 		return nil
 	}
-	if err != pg.ErrNoRows {
+	if !errors.Is(err, pg.ErrNoRows) {
 		// Unexpected error
 		db.log.WithError(err).Error("unexpected error: couldn't select the current month")
 		return err

--- a/internal/db/pg/search_unit_test.go
+++ b/internal/db/pg/search_unit_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/money"
 )
 
-// nolint:lll
 func TestBuildSearchSpendsQuery(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/pg/spend_type.go
+++ b/internal/db/pg/spend_type.go
@@ -18,7 +18,7 @@ func (db DB) GetSpendType(ctx context.Context, id uint) (*db_common.SpendType, e
 
 	spendType := &SpendType{ID: id}
 	if err := db.db.Select(spendType); err != nil {
-		if err == pg.ErrNoRows {
+		if errors.Is(err, pg.ErrNoRows) {
 			err = db_common.ErrSpendTypeNotExist
 		}
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -15,7 +15,7 @@ import (
 // {year}/{month}/{day} {hour}:{minute}:{second}
 const timeLayout = "2006/01/02 15:04:05"
 
-type Config struct { // nolint:maligned
+type Config struct {
 	Debug bool `env:"DEBUG" envDefault:"false"`
 
 	// Mode is a mode of Logger. Valid options: prod, production, dev, develop.

--- a/internal/web/pages.go
+++ b/internal/web/pages.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -54,7 +55,7 @@ func (s Server) yearPage(w http.ResponseWriter, r *http.Request) {
 
 	months, err := s.db.GetMonths(r.Context(), year)
 	// Render the page even theare no months for passed year
-	if err != nil && err != db.ErrYearNotExist {
+	if err != nil && !errors.Is(err, db.ErrYearNotExist) {
 		msg := dbErrorMessagePrefix + "couldn't get months"
 		s.processErrorWithPage(r.Context(), log, w, msg, http.StatusInternalServerError, err)
 		return

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -166,7 +166,7 @@ func (s *Server) Prepare() {
 func (s Server) ListenAndServer() error {
 	s.log.Info("start server")
 
-	if err := s.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	if err := s.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		s.log.WithError(err).Error("server error")
 		return errors.Wrap(err, "server error")
 	}


### PR DESCRIPTION
- Update `golangci-lint` to v1.27.0
- Update linter config
- Fix new warnings
- Refactor workflow:
  - use multiple jobs
  - use Go 1.14 instead of Go 1.13
  - use `golangci-lint` as a [GitHub Action](https://github.com/golangci/golangci-lint-action)