### PR TITLE
Format links

### DIFF
--- a/static/js/link-formatter.js
+++ b/static/js/link-formatter.js
@@ -1,0 +1,12 @@
+// We don't need perfect regexp for links. So, use this one without any strict checks for url correctness
+const urlRegexp = /((https?:\/\/[^\s\/]+)[^\s]*)/g;
+
+function formatLinks(querySelector) {
+	const elements = document.querySelectorAll(querySelector);
+	for (const elem of elements) {
+		// Ignore all empty elements or elements with at least one child
+		if (elem.children.length !== 0 || elem.innerHTML === "") continue;
+
+		elem.innerHTML = elem.innerHTML.replace(urlRegexp, '<a href="$1" target="_blank" title="$1">$2/…</a>');
+	}
+}

--- a/templates/overview_year_month.html
+++ b/templates/overview_year_month.html
@@ -1556,6 +1556,14 @@
 
 	</script>
 
+	<!-- Link Formatter -->
+	<script src="/static/js/link-formatter.js"></script>
+	<script>
+		window.addEventListener("load", () => {
+			formatLinks(".detailed-info__block__table__notes:not(.noselect)");
+		})
+	</script>
+
 	<!-- Spend Autocompletion -->
 	<script>
 		// A special character which is added to option values in <datalist>.

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -649,6 +649,14 @@
 			form.submit();
 		}
 	</script>
+
+	<!-- Link Formatter -->
+	<script src="/static/js/link-formatter.js"></script>
+	<script>
+		window.addEventListener("load", () => {
+			formatLinks(".search__results__table__notes");
+		})
+	</script>
 </body>
 
 </html>


### PR DESCRIPTION
Format links on *Month* and *Search Spends* pages. For example, link `https://github.com/ShoshinNikita/budget-manager` will become `https://github.com/...`

Resolve #119 

