### PR TITLE
Support nested Spend Types on backend

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -107,6 +107,8 @@ definitions:
         type: integer
       name:
         type: string
+      parent_id:
+        type: integer
     type: object
   models.AddIncomeReq:
     properties:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -209,6 +209,8 @@ definitions:
       name:
         example: Food
         type: string
+      parent_id:
+        type: integer
     required:
     - name
     type: object
@@ -278,9 +280,11 @@ definitions:
       name:
         example: Vegetables
         type: string
+      parent_id:
+        example: 1
+        type: integer
     required:
     - id
-    - name
     type: object
   models.GetDayResp:
     properties:

--- a/internal/db/args.go
+++ b/internal/db/args.go
@@ -66,6 +66,21 @@ type EditSpendArgs struct {
 }
 
 // ----------------------------------------------------
+// Spend
+// ----------------------------------------------------
+
+type AddSpendTypeArgs struct {
+	Name     string
+	ParentID uint // optional
+}
+
+type EditSpendTypeArgs struct {
+	ID       uint
+	Name     *string
+	ParentID *uint
+}
+
+// ----------------------------------------------------
 // Search
 // ----------------------------------------------------
 

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -79,6 +79,7 @@ type Spend struct {
 
 // SpendType contains information about spend type
 type SpendType struct {
-	ID   uint   `json:"id"`
-	Name string `json:"name"`
+	ID       uint   `json:"id"`
+	Name     string `json:"name"`
+	ParentID uint   `json:"parent_id"`
 }

--- a/internal/db/pg/migrations/4_support_nested_types.go
+++ b/internal/db/pg/migrations/4_support_nested_types.go
@@ -1,0 +1,19 @@
+package migrations
+
+import (
+	"github.com/go-pg/migrations/v7"
+)
+
+func registerAddParentIDToSpendTypes(migrator *migrations.Collection) {
+	migrator.MustRegisterTx(addParentIDToSpendTypesUp, addParentIDToSpendTypesDown)
+}
+
+func addParentIDToSpendTypesUp(db migrations.DB) error {
+	_, err := db.Exec(`ALTER TABLE spend_types ADD COLUMN parent_id bigint REFERENCES spend_types(id);`)
+	return err
+}
+
+func addParentIDToSpendTypesDown(db migrations.DB) error {
+	_, err := db.Exec(`ALTER TABLE spend_types DROP COLUMN parent_id;`)
+	return err
+}

--- a/internal/db/pg/migrations/migrations.go
+++ b/internal/db/pg/migrations/migrations.go
@@ -13,11 +13,12 @@ func NewMigrator() *migrations.Collection {
 }
 
 // Number of registered migrations. It can be used to check whether we registered all migrations
-const MigrationNumber = 3
+const MigrationNumber = 4
 
 // RegisterMigrations registers all migrations
 func registerMigrations(migrator *migrations.Collection) {
 	registerInit(migrator)
 	registerAddNotNull(migrator)
 	registerAddForeignKeys(migrator)
+	registerAddParentIDToSpendTypes(migrator)
 }

--- a/internal/db/pg/monthly_payment_test.go
+++ b/internal/db/pg/monthly_payment_test.go
@@ -26,7 +26,7 @@ func TestAddMonthlyPayment(t *testing.T) {
 	)
 	require.Nil(err)
 
-	_, err = db.AddSpendType(context.Background(), "spend type")
+	_, err = db.AddSpendType(context.Background(), common.AddSpendTypeArgs{Name: "spend type"})
 	require.Nil(err)
 
 	payments := []MonthlyPayment{

--- a/internal/db/pg/pg.go
+++ b/internal/db/pg/pg.go
@@ -212,6 +212,7 @@ func (db *DB) checkCreatedTables() error {
 			columns: []column{
 				{Name: "id", Type: "bigint", Default: "nextval('spend_types_id_seq'::regclass)"},
 				{Name: "name", Type: "text"},
+				{Name: "parent_id", Type: "bigint", IsNull: true},
 			},
 		},
 		{
@@ -235,7 +236,7 @@ func (db *DB) checkCreatedTables() error {
 			return errors.Wrapf(err, "couldn't get description of table '%s'", table.name)
 		}
 
-		err = errors.Wrapf(err, "table has wrong columns: '%+v', expected: '%+v'", columnsInDB, table.columns)
+		err = errors.Errorf("table '%s' has wrong columns: '%+v', expected: '%+v'", table.name, columnsInDB, table.columns)
 		if len(table.columns) != len(columnsInDB) {
 			return err
 		}

--- a/internal/db/pg/search.go
+++ b/internal/db/pg/search.go
@@ -34,10 +34,7 @@ func (db DB) SearchSpends(ctx context.Context, args common.SearchSpendsArgs) ([]
 		}
 		if pgSpends[i].Type.ID != 0 {
 			// Don't check if a name is empty because Spend Types with non-zero id always have a name
-			s.Type = &common.SpendType{
-				ID:   pgSpends[i].Type.ID,
-				Name: pgSpends[i].Type.Name,
-			}
+			s.Type = pgSpends[i].Type.ToCommon()
 		}
 		spends = append(spends, s)
 	}
@@ -55,10 +52,7 @@ type searchSpendsModel struct {
 	Title string
 	Notes string
 	Cost  money.Money
-	Type  struct {
-		ID   uint
-		Name string
-	}
+	Type  SpendType
 }
 
 // buildSearchSpendsQuery builds a query to search for spends
@@ -99,6 +93,7 @@ func (DB) buildSearchSpendsQuery(tx *pg.Tx, args common.SearchSpendsArgs) *orm.Q
 		ColumnExpr("spend.cost AS cost").
 		ColumnExpr("spend_type.id AS type__id").
 		ColumnExpr("spend_type.name AS type__name").
+		ColumnExpr("spend_type.parent_id AS type__parent_id").
 		//
 		Join("INNER JOIN days AS day ON day.id = spend.day_id").
 		Join("INNER JOIN months AS month ON month.id = day.month_id").

--- a/internal/db/pg/search_test.go
+++ b/internal/db/pg/search_test.go
@@ -47,7 +47,7 @@ func TestSearchSpends(t *testing.T) {
 	firstSpendType := &common.SpendType{ID: 1, Name: "first type"}
 	secondSpendType := &common.SpendType{ID: 2, Name: "second type"}
 	for _, t := range []*common.SpendType{firstSpendType, secondSpendType} {
-		_, err := db.AddSpendType(context.Background(), t.Name)
+		_, err := db.AddSpendType(context.Background(), common.AddSpendTypeArgs{Name: t.Name})
 		globalRequire.Nil(err)
 	}
 

--- a/internal/db/pg/search_unit_test.go
+++ b/internal/db/pg/search_unit_test.go
@@ -24,7 +24,7 @@ func TestBuildSearchSpendsQuery(t *testing.T) {
 		query := `
 			SELECT spend.id AS id, month.year AS year, month.month AS month, day.day AS day,
 			       spend.title AS title, spend.notes AS notes, spend.cost AS cost,
-			       spend_type.id AS type__id, spend_type.name AS type__name
+			       spend_type.id AS type__id, spend_type.name AS type__name, spend_type.parent_id AS type__parent_id
 
 			 FROM spends AS "spend"
 			      INNER JOIN days AS day

--- a/internal/db/pg/spend_test.go
+++ b/internal/db/pg/spend_test.go
@@ -95,7 +95,7 @@ func TestEditSpend(t *testing.T) {
 
 	// Add Spend Types
 	for _, name := range []string{"first", "second"} {
-		_, err := db.AddSpendType(context.Background(), name)
+		_, err := db.AddSpendType(context.Background(), common.AddSpendTypeArgs{Name: name})
 		require.Nil(err)
 	}
 

--- a/internal/db/pg/spend_type.go
+++ b/internal/db/pg/spend_type.go
@@ -13,8 +13,9 @@ import (
 type SpendType struct {
 	tableName struct{} `pg:"spend_types"`
 
-	ID   uint   `pg:"id,pk"`
-	Name string `pg:"name"`
+	ID       uint   `pg:"id,pk"`
+	Name     string `pg:"name"`
+	ParentID uint   `pg:"parent_id"`
 }
 
 // ToCommon converts SpendType to common SpendType structure from
@@ -24,8 +25,9 @@ func (s *SpendType) ToCommon() *common.SpendType {
 		return nil
 	}
 	return &common.SpendType{
-		ID:   s.ID,
-		Name: s.Name,
+		ID:       s.ID,
+		Name:     s.Name,
+		ParentID: s.ParentID,
 	}
 }
 

--- a/internal/db/pg/spend_type_test.go
+++ b/internal/db/pg/spend_type_test.go
@@ -28,7 +28,7 @@ func TestAddSpendType(t *testing.T) {
 			SpendType: SpendType{ID: 1, Name: "first type"},
 		},
 		{
-			SpendType: SpendType{ID: 2, Name: "второй тип"},
+			SpendType: SpendType{ID: 2, Name: "второй тип", ParentID: 1},
 		},
 		{
 			SpendType: SpendType{ID: 0, Name: ""},
@@ -38,7 +38,7 @@ func TestAddSpendType(t *testing.T) {
 
 	// Add Spend Types
 	for _, t := range spendTypes {
-		id, err := db.AddSpendType(context.Background(), t.Name)
+		id, err := db.AddSpendType(context.Background(), common.AddSpendTypeArgs{Name: t.Name, ParentID: t.ParentID})
 		if t.isError {
 			require.NotNil(err)
 			continue
@@ -87,18 +87,31 @@ func TestEditSpendType(t *testing.T) {
 			origin: SpendType{ID: 1, Name: "first type"},
 			edited: SpendType{ID: 1, Name: "new name"},
 		},
+		{
+			origin: SpendType{ID: 2, Name: "second type"},
+			edited: SpendType{ID: 2, Name: "new name", ParentID: 1},
+		},
+		{
+			origin: SpendType{ID: 3, Name: "third type", ParentID: 1},
+			edited: SpendType{ID: 3, Name: "third type", ParentID: 2},
+		},
 	}
 
 	// Add Spend Types
 	for _, t := range spendTypes {
-		id, err := db.AddSpendType(context.Background(), t.origin.Name)
+		id, err := db.AddSpendType(context.Background(), common.AddSpendTypeArgs{Name: t.origin.Name})
 		require.Nil(err)
 		require.Equal(t.origin.ID, id)
 	}
 
 	// Edit Spend Types
 	for _, t := range spendTypes {
-		err := db.EditSpendType(context.Background(), t.edited.ID, t.edited.Name)
+		args := common.EditSpendTypeArgs{ID: t.edited.ID, Name: &t.edited.Name}
+		if t.origin.ParentID != t.edited.ParentID {
+			args.ParentID = &t.edited.ParentID
+		}
+
+		err := db.EditSpendType(context.Background(), args)
 		require.Nil(err)
 	}
 
@@ -124,7 +137,7 @@ func TestDeleteSpendType(t *testing.T) {
 
 	// Add Spend Types
 	for _, t := range spendTypes {
-		id, err := db.AddSpendType(context.Background(), t.Name)
+		id, err := db.AddSpendType(context.Background(), common.AddSpendTypeArgs{Name: t.Name})
 		require.Nil(err)
 		require.Equal(t.ID, id)
 	}

--- a/internal/web/api/models/spend_type.go
+++ b/internal/web/api/models/spend_type.go
@@ -13,7 +13,8 @@ type GetSpendTypesResp struct {
 type AddSpendTypeReq struct {
 	Request
 
-	Name string `json:"name" validate:"required" example:"Food"`
+	Name     string `json:"name" validate:"required" example:"Food"`
+	ParentID uint   `json:"parent_id"`
 }
 
 func (req AddSpendTypeReq) Check() error {
@@ -32,15 +33,16 @@ type AddSpendTypeResp struct {
 type EditSpendTypeReq struct {
 	Request
 
-	ID   uint   `json:"id" validate:"required" example:"1"`
-	Name string `json:"name" validate:"required" example:"Vegetables"`
+	ID       uint    `json:"id" validate:"required" example:"1"`
+	Name     *string `json:"name" example:"Vegetables"`
+	ParentID *uint   `json:"parent_id" example:"1"`
 }
 
 func (req EditSpendTypeReq) Check() error {
 	if req.ID == 0 {
 		return emptyOrZeroFieldError("id")
 	}
-	if req.Name == "" {
+	if req.Name != nil && *req.Name == "" {
 		return emptyFieldError("name")
 	}
 	return nil

--- a/internal/web/api/spend_type.go
+++ b/internal/web/api/spend_type.go
@@ -20,8 +20,8 @@ type SpendTypesHandlers struct {
 
 type SpendTypesDB interface {
 	GetSpendTypes(ctx context.Context) ([]*db.SpendType, error)
-	AddSpendType(ctx context.Context, name string) (id uint, err error)
-	EditSpendType(ctx context.Context, id uint, newName string) error
+	AddSpendType(ctx context.Context, args db.AddSpendTypeArgs) (id uint, err error)
+	EditSpendType(ctx context.Context, args db.EditSpendTypeArgs) error
 	RemoveSpendType(ctx context.Context, id uint) error
 }
 
@@ -79,7 +79,10 @@ func (h SpendTypesHandlers) AddSpendType(w http.ResponseWriter, r *http.Request)
 
 	// Process
 	log.Debug("add Spend Type")
-	id, err := h.db.AddSpendType(ctx, strings.TrimSpace(req.Name))
+	args := db.AddSpendTypeArgs{
+		Name: strings.TrimSpace(req.Name),
+	}
+	id, err := h.db.AddSpendType(ctx, args)
 	if err != nil {
 		utils.ProcessError(ctx, log, w, "couldn't add Spend Type", http.StatusInternalServerError, err)
 		return
@@ -123,7 +126,12 @@ func (h SpendTypesHandlers) EditSpendType(w http.ResponseWriter, r *http.Request
 
 	// Process
 	log.Debug("edit Spend Type")
-	err := h.db.EditSpendType(ctx, req.ID, strings.TrimSpace(req.Name))
+	newName := strings.TrimSpace(req.Name)
+	args := db.EditSpendTypeArgs{
+		ID:   req.ID,
+		Name: &newName,
+	}
+	err := h.db.EditSpendType(ctx, args)
 	if err != nil {
 		switch err {
 		case db.ErrSpendTypeNotExist:

--- a/internal/web/api/spend_type.go
+++ b/internal/web/api/spend_type.go
@@ -75,12 +75,13 @@ func (h SpendTypesHandlers) AddSpendType(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	log = log.WithField("name", req.Name)
+	log = log.WithFields(logrus.Fields{"name": req.Name, "parent_id": req.ParentID})
 
 	// Process
 	log.Debug("add Spend Type")
 	args := db.AddSpendTypeArgs{
-		Name: strings.TrimSpace(req.Name),
+		Name:     strings.TrimSpace(req.Name),
+		ParentID: req.ParentID,
 	}
 	id, err := h.db.AddSpendType(ctx, args)
 	if err != nil {
@@ -126,10 +127,11 @@ func (h SpendTypesHandlers) EditSpendType(w http.ResponseWriter, r *http.Request
 
 	// Process
 	log.Debug("edit Spend Type")
-	newName := strings.TrimSpace(req.Name)
+
 	args := db.EditSpendTypeArgs{
-		ID:   req.ID,
-		Name: &newName,
+		ID:       req.ID,
+		Name:     trimSpacePointer(req.Name),
+		ParentID: req.ParentID,
 	}
 	err := h.db.EditSpendType(ctx, args)
 	if err != nil {

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -366,7 +366,7 @@ func TestHandlers_MonthlyPayment(t *testing.T) {
 
 	// Add Spend Types for testing
 	for _, name := range []string{"first", "second"} {
-		_, err := server.db.AddSpendType(context.Background(), name)
+		_, err := server.db.AddSpendType(context.Background(), db.AddSpendTypeArgs{Name: name})
 		requireGlobal.Nil(err)
 	}
 
@@ -698,7 +698,7 @@ func TestHandlers_Spend(t *testing.T) {
 
 	// Add Spend Types for testing
 	for _, name := range []string{"first", "second"} {
-		_, err := server.db.AddSpendType(context.Background(), name)
+		_, err := server.db.AddSpendType(context.Background(), db.AddSpendTypeArgs{Name: name})
 		requireGlobal.Nil(err)
 	}
 

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -1018,6 +1018,9 @@ func testHandlers_Spend_RemoveSpend(t *testing.T, server *Server) {
 // -------------------------------------------------
 
 func TestHandlers_SpendType(t *testing.T) {
+	newName := func(s string) *string { return &s }
+	newParentID := func(u uint) *uint { return &u }
+
 	requireGlobal := require.New(t)
 	server := initServer(requireGlobal)
 	defer cleanUp(requireGlobal, server)
@@ -1158,8 +1161,9 @@ func TestHandlers_SpendType(t *testing.T) {
 			{
 				desc: "valid request (edit name)",
 				req: models.EditSpendTypeReq{
-					ID:   1,
-					Name: "updated name",
+					ID:       1,
+					Name:     newName("updated name"),
+					ParentID: newParentID(2),
 				},
 				statusCode: http.StatusOK,
 				resp: models.Response{
@@ -1172,7 +1176,7 @@ func TestHandlers_SpendType(t *testing.T) {
 				desc: "invalid request (empty name)",
 				req: models.EditSpendTypeReq{
 					ID:   2,
-					Name: "",
+					Name: newName(""),
 				},
 				statusCode: http.StatusBadRequest,
 				resp: models.Response{
@@ -1220,7 +1224,7 @@ func TestHandlers_SpendType(t *testing.T) {
 
 	ok = t.Run("CheckSpendTypes", func(t *testing.T) {
 		want := []*db.SpendType{
-			{ID: 1, Name: "updated name"},
+			{ID: 1, Name: "updated name", ParentID: 2},
 			{ID: 2, Name: "second type"},
 		}
 		// Prepare


### PR DESCRIPTION
Update schema of table `spend_types` and API to support nested *Spend Types*

This PR relates to #118 