### PR TITLE
Support nested Spend Types on frontend

### DIFF
--- a/internal/web/api/spend_type_test.go
+++ b/internal/web/api/spend_type_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ShoshinNikita/budget-manager/internal/db"
+)
+
+func TestCheckSpendTypeForCycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		desc string
+		//
+		spendTypes  []db.SpendType
+		originalID  uint
+		newParentID uint
+		//
+		wantErr      string
+		wantHasCycle bool
+	}{
+		{
+			desc: "no cycle",
+			//
+			spendTypes: []db.SpendType{
+				{ID: 1},
+				{ID: 2, ParentID: 3},
+				{ID: 3},
+			},
+			originalID:  1,
+			newParentID: 2,
+			//
+			wantErr:      "",
+			wantHasCycle: false,
+		},
+		{
+			desc: "has cycle",
+			//
+			spendTypes: []db.SpendType{
+				{ID: 1},
+				{ID: 2, ParentID: 3},
+				{ID: 3, ParentID: 1},
+			},
+			originalID:  1,
+			newParentID: 2,
+			//
+			wantErr:      "",
+			wantHasCycle: true,
+		},
+		{
+			desc: "already has cycle",
+			//
+			spendTypes: []db.SpendType{
+				{ID: 1},
+				{ID: 2, ParentID: 3},
+				{ID: 3, ParentID: 2},
+			},
+			originalID:  1,
+			newParentID: 2,
+			//
+			wantErr:      "Spend Type has too many parents or already has a cycle",
+			wantHasCycle: false,
+		},
+		{
+			desc: "invalid Spend Type",
+			//
+			spendTypes: []db.SpendType{
+				{ID: 1},
+				{ID: 2, ParentID: 4},
+			},
+			originalID:  1,
+			newParentID: 2,
+			//
+			wantErr:      "invalid Spend Type",
+			wantHasCycle: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.desc, func(t *testing.T) {
+			gotHasCycle, gotErr := checkSpendTypeForCycle(tt.spendTypes, tt.originalID, tt.newParentID)
+			if tt.wantErr != "" {
+				require.EqualError(t, gotErr, tt.wantErr)
+			} else {
+				require.Nil(t, gotErr)
+			}
+			require.Equal(t, tt.wantHasCycle, gotHasCycle)
+		})
+	}
+}

--- a/internal/web/pages/pages.go
+++ b/internal/web/pages/pages.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html/template"
 	"io"
 	"net/http"
 	"sort"
@@ -239,6 +240,7 @@ func (h Handlers) MonthPage(w http.ResponseWriter, r *http.Request) {
 		SpendTypes    []SpendType
 		ToShortMonth  func(time.Month) string
 		SumSpendCosts func([]db.Spend) money.Money
+		ToHTMLAttr    func(string) template.HTMLAttr
 		//
 		Footer FooterTemplateData
 	}{
@@ -246,6 +248,7 @@ func (h Handlers) MonthPage(w http.ResponseWriter, r *http.Request) {
 		SpendTypes:    spendTypes,
 		ToShortMonth:  toShortMonth,
 		SumSpendCosts: sumSpendCosts,
+		ToHTMLAttr:    func(s string) template.HTMLAttr { return template.HTMLAttr(s) }, //nolint:gosec
 		//
 		Footer: FooterTemplateData{
 			Version: version.Version,

--- a/internal/web/pages/pages.go
+++ b/internal/web/pages/pages.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -223,6 +224,10 @@ func (h Handlers) MonthPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	sort.Slice(spendTypes, func(i, j int) bool {
+		return spendTypes[i].Name < spendTypes[j].Name
+	})
+
 	resp := struct {
 		db.Month
 		SpendTypes    []db.SpendType
@@ -350,7 +355,7 @@ func (h Handlers) SearchSpendsPage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Sort
-	sort := func() db.SearchSpendsColumn {
+	sortType := func() db.SearchSpendsColumn {
 		switch r.FormValue("sort") {
 		case "title":
 			return db.SortSpendsByTitle
@@ -379,7 +384,7 @@ func (h Handlers) SearchSpendsPage(w http.ResponseWriter, r *http.Request) {
 		MaxCost:     maxCost,
 		WithoutType: withoutType,
 		TypeIDs:     typeIDs,
-		Sort:        sort,
+		Sort:        sortType,
 		Order:       order,
 		// TODO
 		TitleExactly: false,
@@ -398,6 +403,10 @@ func (h Handlers) SearchSpendsPage(w http.ResponseWriter, r *http.Request) {
 		h.processInternalErrorWithPage(ctx, log, w, msg, err)
 		return
 	}
+
+	sort.Slice(spendTypes, func(i, j int) bool {
+		return spendTypes[i].Name < spendTypes[j].Name
+	})
 
 	// Execute the template
 	resp := struct {

--- a/internal/web/pages/spend_type.go
+++ b/internal/web/pages/spend_type.go
@@ -1,0 +1,94 @@
+package pages
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ShoshinNikita/budget-manager/internal/db"
+)
+
+type SpendType struct {
+	db.SpendType
+	// FullName is a composite name that contains names of parent Spend Types
+	FullName string
+}
+
+func (h Handlers) getSpendTypesWithFullNames(ctx context.Context) ([]SpendType, error) {
+	spendTypes, err := h.db.GetSpendTypes(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	spendTypesMap := make(map[uint]db.SpendType, len(spendTypes))
+	for _, t := range spendTypes {
+		spendTypesMap[t.ID] = t
+	}
+
+	res := make([]SpendType, 0, len(spendTypes))
+	for _, t := range spendTypes {
+		res = append(res, SpendType{
+			SpendType: t,
+			FullName:  getSpendTypeFullName(spendTypesMap, t.ID),
+		})
+	}
+	return res, nil
+}
+
+func getSpendTypeFullName(spendTypes map[uint]db.SpendType, typeID uint) string {
+	const maxDepth = 15
+
+	var getFullName func(currentDepth int, currentType db.SpendType) string
+	getFullName = func(currentDepth int, currentType db.SpendType) string {
+		if currentDepth >= maxDepth {
+			return "..."
+		}
+		if currentType.ParentID == 0 {
+			return currentType.Name
+		}
+
+		nextType := spendTypes[currentType.ParentID]
+		if nextType.Name == "" {
+			return currentType.Name
+		}
+
+		// Use thin spaces ' ' to separate names
+		return fmt.Sprintf("%s / %s", getFullName(currentDepth+1, nextType), currentType.Name)
+	}
+
+	if spendType, ok := spendTypes[typeID]; ok {
+		return getFullName(0, spendType)
+	}
+	return ""
+}
+
+// populateMonthlyPaymentsWithFullSpendTypeNames replaces Spend Type names to full ones
+func populateMonthlyPaymentsWithFullSpendTypeNames(spendTypes []SpendType, monthlyPayments []db.MonthlyPayment) {
+	fullNames := make(map[uint]string, len(spendTypes))
+	for _, t := range spendTypes {
+		fullNames[t.ID] = t.FullName
+	}
+
+	for i := range monthlyPayments {
+		if monthlyPayments[i].Type != nil {
+			if fullName, ok := fullNames[monthlyPayments[i].Type.ID]; ok {
+				monthlyPayments[i].Type.Name = fullName
+			}
+		}
+	}
+}
+
+// populateSpendsWithFullSpendTypeNames replaces Spend Type names to full ones
+func populateSpendsWithFullSpendTypeNames(spendTypes []SpendType, spends []db.Spend) {
+	fullNames := make(map[uint]string, len(spendTypes))
+	for _, t := range spendTypes {
+		fullNames[t.ID] = t.FullName
+	}
+
+	for i := range spends {
+		if spends[i].Type != nil {
+			if fullName, ok := fullNames[spends[i].Type.ID]; ok {
+				spends[i].Type.Name = fullName
+			}
+		}
+	}
+}

--- a/internal/web/pages/spend_type_test.go
+++ b/internal/web/pages/spend_type_test.go
@@ -34,22 +34,65 @@ func TestGetSpendTypeFullName(t *testing.T) {
 
 	tests := []struct {
 		typeID uint
-		want   string
+		//
+		wantFullName  string
+		wantParentIDs map[uint]struct{}
 	}{
-		{typeID: 1, want: joinFullName("1")},
-		{typeID: 2, want: joinFullName("1", "2")},
-		{typeID: 3, want: joinFullName("1", "3")},
-		{typeID: 4, want: joinFullName("1", "2", "4")},
-		{typeID: 5, want: joinFullName("...", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5")},
-		{typeID: 6, want: joinFullName("...", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6")},
-		{typeID: 7, want: joinFullName("...", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7")},
-		{typeID: 8, want: joinFullName("9", "8")},
+		{
+			typeID: 1,
+			//
+			wantFullName:  joinFullName("1"),
+			wantParentIDs: map[uint]struct{}{},
+		},
+		{
+			typeID: 2,
+			//
+			wantFullName:  joinFullName("1", "2"),
+			wantParentIDs: map[uint]struct{}{1: {}},
+		},
+		{
+			typeID: 3,
+			//
+			wantFullName:  joinFullName("1", "3"),
+			wantParentIDs: map[uint]struct{}{1: {}},
+		},
+		{
+			typeID: 4,
+			//
+			wantFullName:  joinFullName("1", "2", "4"),
+			wantParentIDs: map[uint]struct{}{1: {}, 2: {}},
+		},
+		{
+			typeID: 5,
+			//
+			wantFullName:  joinFullName("...", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5"),
+			wantParentIDs: map[uint]struct{}{5: {}},
+		},
+		{
+			typeID: 6,
+			//
+			wantFullName:  joinFullName("...", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6"),
+			wantParentIDs: map[uint]struct{}{6: {}, 7: {}},
+		},
+		{
+			typeID: 7,
+			//
+			wantFullName:  joinFullName("...", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7"),
+			wantParentIDs: map[uint]struct{}{6: {}, 7: {}},
+		},
+		{
+			typeID: 8,
+			//
+			wantFullName:  joinFullName("9", "8"),
+			wantParentIDs: map[uint]struct{}{9: {}},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			got := getSpendTypeFullName(spendTypes, tt.typeID)
-			require.Equal(t, tt.want, got)
+			gotFullName, gotParentIDs := getSpendTypeFullName(spendTypes, tt.typeID)
+			require.Equal(t, tt.wantFullName, gotFullName)
+			require.Equal(t, tt.wantParentIDs, gotParentIDs)
 		})
 	}
 }

--- a/internal/web/pages/spend_type_test.go
+++ b/internal/web/pages/spend_type_test.go
@@ -1,0 +1,55 @@
+package pages
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ShoshinNikita/budget-manager/internal/db"
+)
+
+func TestGetSpendTypeFullName(t *testing.T) {
+	t.Parallel()
+
+	spendTypes := map[uint]db.SpendType{
+		1: {ID: 1, Name: "1", ParentID: 0},
+		//
+		2: {ID: 2, Name: "2", ParentID: 1},
+		3: {ID: 3, Name: "3", ParentID: 1},
+		4: {ID: 4, Name: "4", ParentID: 2},
+		//
+		5: {ID: 5, Name: "5", ParentID: 5},
+		//
+		6: {ID: 6, Name: "6", ParentID: 7},
+		7: {ID: 7, Name: "7", ParentID: 6},
+		//
+		8: {ID: 8, Name: "8", ParentID: 9},
+		9: {ID: 8, Name: "9", ParentID: 10},
+	}
+
+	joinFullName := func(names ...string) string {
+		return strings.Join(names, " / ")
+	}
+
+	tests := []struct {
+		typeID uint
+		want   string
+	}{
+		{typeID: 1, want: joinFullName("1")},
+		{typeID: 2, want: joinFullName("1", "2")},
+		{typeID: 3, want: joinFullName("1", "3")},
+		{typeID: 4, want: joinFullName("1", "2", "4")},
+		{typeID: 5, want: joinFullName("...", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5", "5")},
+		{typeID: 6, want: joinFullName("...", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6")},
+		{typeID: 7, want: joinFullName("...", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7", "6", "7")},
+		{typeID: 8, want: joinFullName("9", "8")},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run("", func(t *testing.T) {
+			got := getSpendTypeFullName(spendTypes, tt.typeID)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/web/pages/utils_test.go
+++ b/internal/web/pages/utils_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestToShortMonth(t *testing.T) {
+	t.Parallel()
+
 	require := require.New(t)
 
 	tests := []struct {

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -146,12 +146,18 @@ select {
 	appearance: none;
 	-moz-appearance: none;
 	-webkit-appearance: none;
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round'><polyline points='19 12 12 19 5 12'></polyline></svg>")
+		no-repeat right;
 	background-color: white;
-	border: 1px solid var(--border-accent-color);
+	border: none;
+	border-bottom: 1px solid var(--border-color);
 	cursor: pointer;
 	padding: 2px 16px 2px 0;
-	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='3' stroke-linecap='round'><polyline points='19 12 12 19 5 12'></polyline></svg>")
-		no-repeat right;
+	scrollbar-width: unset;
+}
+
+select:focus {
+	border-color: var(--border-accent-color);
 }
 
 select:active {

--- a/static/css/common.css
+++ b/static/css/common.css
@@ -5,6 +5,7 @@
 	--border-color: #88888818;
 	--border-accent-color: #88888860;
 	--hover-color: #e4e4e438;
+	--disabled-color: #00000050;
 }
 
 /* | Common */
@@ -158,6 +159,13 @@ select {
 
 select:focus {
 	border-color: var(--border-accent-color);
+}
+
+select.reverse {
+	background-position: left;
+	padding-right: 0;
+	padding-left: 16px;
+	text-align: right;
 }
 
 select:active {

--- a/templates/overview_year_month.html
+++ b/templates/overview_year_month.html
@@ -826,7 +826,7 @@
 							{{ if eq $currentType.ParentID .ID }}
 							{{ $attributes = (printf "%s %s" $attributes "selected") }}
 							{{ end }}
-							{{ if eq $currentType.ID .ID }}
+							{{ if not (call $.ShouldSuggestSpendType $currentType .) }}
 							{{ $attributes = (printf "%s %s" $attributes "disabled style='color: var(--disabled-color)'") }}
 							{{ end }}
 

--- a/templates/overview_year_month.html
+++ b/templates/overview_year_month.html
@@ -258,9 +258,11 @@
 			box-shadow: 0px 0px 10px 10px #00000020;
 			display: none;
 			margin: 9vh auto 5vh;
-			max-width: 700px;
+			max-width: 80%;
+			min-width: 700px;
+			overflow-x: auto;
 			padding: 20px;
-			width: 80%;
+			width: max-content;
 		}
 
 		.modal-window__header {
@@ -286,15 +288,19 @@
 		}
 
 		.modal-window__manage-types__spend-type {
-			column-gap: 20px;
+			column-gap: 10px;
 			display: grid;
-			grid-template-columns: 200px 30px;
+			grid-template-columns: max-content 5px 200px auto;
 			width: min-content;
 			margin: 0 auto 5px;
 		}
 
 		.modal-window__manage-types__spend-type:last-child {
 			margin-bottom: 20px;
+		}
+
+		.modal-window__manage-types__spend-type>span {
+			opacity: 0.5;
 		}
 
 		.modal-window__manage-types__spend-type>.feather-icon>svg {
@@ -811,11 +817,30 @@
 
 					{{ range .SpendTypes }}
 					<div id="modal-window__manage-types__spend-type-{{ .ID }}" class="modal-window__manage-types__spend-type">
+						{{ $currentType := . }}
+						<select id="edit-spend-type-parent-id-{{ .ID }}" class="reverse" autocomplete="off" title="Parent Spend Type">
+							<option value="0"></option>
+							{{ range $.SpendTypes }}
+
+							{{ $attributes := "" }}
+							{{ if eq $currentType.ParentID .ID }}
+							{{ $attributes = (printf "%s %s" $attributes "selected") }}
+							{{ end }}
+							{{ if eq $currentType.ID .ID }}
+							{{ $attributes = (printf "%s %s" $attributes "disabled style='color: var(--disabled-color)'") }}
+							{{ end }}
+
+							<option value="{{ .ID }}" {{ call $.ToHTMLAttr $attributes }}>{{ .FullName }}</option>
+							{{ end }}
+						</select>
+
+						<span class="noselect">/</span>
+
 						<input type="text" id="edit-spend-type-name-{{ .ID }}" value="{{ .Name }}" autocomplete="off"
 							placeholder="{{ .Name }}">
 
 						<div class="actions-horizontal-list">
-							<div class="feather-icon" title="Save" onclick="editSpendType('{{ .ID }}', '{{ .Name }}')">
+							<div class="feather-icon" title="Save" onclick="editSpendType('{{ .ID }}')">
 								<svg>
 									<use xlink:href="/static/feather/feather-sprite.svg#check" />
 								</svg>
@@ -831,13 +856,30 @@
 
 					<!-- New Spend Type -->
 					<form class="modal-window__manage-types__spend-type" onsubmit="addSpendType()">
+						<select id="new-spend-type-parent-id" class="reverse" autocomplete="off" title="Parent Spend Type">
+							<option value="0"></option>
+							{{ range $.SpendTypes }}
+							<option value="{{ .ID }}">{{ .FullName }}</option>
+							{{ end }}
+						</select>
+
+						<span class="noselect">/</span>
+
 						<input type="text" id="new-spend-type-name" placeholder="New Spend Type" autocomplete="off">
 
-						<button type="submit" class="feather-icon" title="Add">
-							<svg>
-								<use xlink:href="/static/feather/feather-sprite.svg#plus" />
-							</svg>
-						</button>
+						<div class="actions-horizontal-list">
+							<button type="submit" class="feather-icon" title="Add">
+								<svg>
+									<use xlink:href="/static/feather/feather-sprite.svg#plus" />
+								</svg>
+							</button>
+							<!-- Use this disabled and hidden element to align 'Add' button -->
+							<div class="feather-icon" style="opacity: 0; pointer-events: none;">
+								<svg>
+									<use xlink:href="/static/feather/feather-sprite.svg#plus" />
+								</svg>
+							</div>
+						</div>
 					</form>
 				</div>
 			</div>
@@ -1228,30 +1270,34 @@
 				return;
 			}
 
+			// Skip check because user can't specify parent id as not a number
+			const parentID = getValue("new-spend-type-parent-id");
+
 			const fields = {
-				"name": name
+				"name": name,
+				"parent_id": Number(parentID)
 			}
 
 			// Reload on success
 			sendRequest("POST", "/api/spend-types", fields);
 		}
 
-		function editSpendType(id, oldName) {
+		function editSpendType(id) {
 			preventDefault(this);
 
-			const newName = getValue(`edit-spend-type-name-${id}`);
-			if (newName === oldName) {
-				// Do nothing
-				return;
-			}
-			if (newName === "") {
+			const name = getValue(`edit-spend-type-name-${id}`);
+			if (name === "") {
 				processError("Name of Spend Type can't be empty");
 				return;
 			}
 
+			// Skip check because user can't specify parent id as not a number
+			const parentID = getValue(`edit-spend-type-parent-id-${id}`);
+
 			const fields = {
 				"id": Number(id),
-				"name": newName,
+				"name": name,
+				"parent_id": Number(parentID),
 			}
 
 			const handler = () => { spendTypeChanged = true; }

--- a/templates/overview_year_month.html
+++ b/templates/overview_year_month.html
@@ -538,7 +538,7 @@
 										<select id="new-monthly-payment-type" autocomplete="off">
 											<option value="0">-</option>
 											{{ range $.SpendTypes }}
-											<option value="{{ .ID }}">{{ .Name }}</option>
+											<option value="{{ .ID }}">{{ .FullName }}</option>
 											{{ end }}
 										</select>
 									</td>
@@ -661,7 +661,7 @@
 											<select id="new-spend-type-{{ .ID }}" autocomplete="off">
 												<option value="0">-</option>
 												{{ range $.SpendTypes }}
-												<option value="{{ .ID }}">{{ .Name }}</option>
+												<option value="{{ .ID }}">{{ .FullName }}</option>
 												{{ end }}
 											</select>
 										</td>
@@ -754,7 +754,7 @@
 						<select id="modal-window__edit-monthly-payment__type">
 							<option value="0">-</option>
 							{{ range $.SpendTypes }}
-							<option value="{{ .ID }}">{{ .Name }}</option>
+							<option value="{{ .ID }}">{{ .FullName }}</option>
 							{{ end }}
 						</select>
 					</div>
@@ -789,7 +789,7 @@
 						<select id="modal-window__edit-spend__type">
 							<option value="0">-</option>
 							{{ range $.SpendTypes }}
-							<option value="{{ .ID }}">{{ .Name }}</option>
+							<option value="{{ .ID }}">{{ .FullName }}</option>
 							{{ end }}
 						</select>
 					</div>

--- a/templates/search_spends.html
+++ b/templates/search_spends.html
@@ -311,7 +311,7 @@
 							{{ range .SpendTypes }}
 							<div class="search__options__types__type">
 								<input id="search__options__types__type-{{ .ID }}" type="checkbox" name="type_id" value="{{ .ID }}" onclick="resetWithoutType()">
-								<label for="search__options__types__type-{{ .ID }}">{{ .Name }}</label>
+								<label for="search__options__types__type-{{ .ID }}">{{ .FullName }}</label>
 							</div>
 							{{ end }}
 						</div>


### PR DESCRIPTION
- Window to manage *Spend Types* now supports parent types
- Update styles of `<select>` elements: less borders, highlight on focus
- Sort *Spend Types* on pages
- Add check for a cycle in `PUT /api/spend-types` handler

Resolves #118 