### PR TITLE
Refine logging

### DIFF
--- a/cmd/budget-manager/main.go
+++ b/cmd/budget-manager/main.go
@@ -44,7 +44,7 @@ func main() {
 	app := app.NewApp(cfg, log, version, gitHash)
 
 	if err := app.PrepareComponents(); err != nil {
-		log.WithError(err).Fatalln("couldn't prepare components")
+		stdlog.Fatalf("couldn't prepare components: %s\n", err)
 	}
 
 	appErrCh := make(chan error, 1)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -84,9 +84,7 @@ func (app *App) prepareDB() (err error) {
 }
 
 func (app *App) prepareWebServer() {
-	app.server = web.NewServer(
-		app.config.Server, app.db, app.log, app.version, app.gitHash,
-	)
+	app.server = web.NewServer(app.config.Server, app.db, app.log, app.version, app.gitHash)
 	app.server.Prepare()
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	"github.com/ShoshinNikita/budget-manager/internal/db/pg"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/web"
 )
 
@@ -17,7 +17,7 @@ type App struct {
 	gitHash string
 
 	db     Database
-	log    logrus.FieldLogger
+	log    logger.Logger
 	server *web.Server
 
 	shutdownSignal chan struct{}
@@ -32,7 +32,7 @@ type Database interface {
 }
 
 // NewApp returns a new instance of App
-func NewApp(cfg Config, log *logrus.Logger, version, gitHash string) *App {
+func NewApp(cfg Config, log logger.Logger, version, gitHash string) *App {
 	return &App{
 		config:  cfg,
 		version: version,
@@ -90,7 +90,7 @@ func (app *App) prepareWebServer() {
 
 // Run runs web server. This method should be called in a goroutine
 func (app *App) Run() error {
-	app.log.WithFields(logrus.Fields{
+	app.log.WithFields(logger.Fields{
 		"version":  app.version,
 		"git_hash": app.gitHash,
 	}).Info("start app")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -133,7 +133,7 @@ func (app *App) startMonthInit() error {
 
 		select {
 		case now := <-time.After(after):
-			app.log.WithField("date", now.Format("2006-01-02")).Debug("init a new month")
+			app.log.WithField("date", now.Format("2006-01-02")).Info("init a new month")
 
 			if err := app.initMonth(now); err != nil {
 				return errors.Wrap(err, "couldn't init a new month")

--- a/internal/db/pg/pg.go
+++ b/internal/db/pg/pg.go
@@ -45,16 +45,12 @@ func NewDB(config Config, log logrus.FieldLogger) (*DB, error) {
 
 	// Try to ping the DB
 	for i := 0; i < connectRetries; i++ {
-		log := db.log.WithField("try", i+1)
-		if i != 0 {
-			log.Debug("ping DB")
-		}
-
 		err := db.db.Ping(context.Background())
 		if err == nil {
 			break
 		}
-		log.WithError(err).Debug("couldn't ping DB")
+
+		log.WithError(err).WithField("try", i+1).Debug("couldn't ping DB")
 		if i+1 == connectRetries {
 			// Don't sleep extra time
 			return nil, errors.New("database is down")
@@ -87,7 +83,6 @@ func (db *DB) Prepare() error {
 	}
 
 	// Run migrations
-	db.log.Debug("run migrations")
 	oldVersion, newVersion, err := migrator.Run(db.db, "up")
 	if err != nil {
 		return errors.Wrap(err, "couldn't run migrations")
@@ -229,6 +224,5 @@ func (db *DB) checkCreatedTables() error {
 
 // Shutdown closes the connection to the db
 func (db *DB) Shutdown() error {
-	db.log.Debug("close database connection")
 	return db.db.Close()
 }

--- a/internal/db/pg/pg.go
+++ b/internal/db/pg/pg.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/go-pg/pg/v10"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	"github.com/ShoshinNikita/budget-manager/internal/db/pg/migrations"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 )
 
 const (
@@ -28,11 +28,11 @@ type Config struct {
 
 type DB struct {
 	db  *pg.DB
-	log logrus.FieldLogger
+	log logger.Logger
 }
 
 // NewDB creates a new connection to the db and pings it
-func NewDB(config Config, log logrus.FieldLogger) (*DB, error) {
+func NewDB(config Config, log logger.Logger) (*DB, error) {
 	db := &DB{
 		log: log.WithField("db_type", "pg"),
 		db: pg.Connect(&pg.Options{
@@ -88,7 +88,7 @@ func (db *DB) Prepare() error {
 		return errors.Wrap(err, "couldn't run migrations")
 	}
 
-	db.log.WithFields(logrus.Fields{
+	db.log.WithFields(logger.Fields{
 		"old_version": oldVersion, "new_version": newVersion,
 	}).Debug("migration process was finished")
 

--- a/internal/logger/dev_format.go
+++ b/internal/logger/dev_format.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"bytes"
 	"fmt"
+	"reflect"
 	"sort"
 
 	"github.com/fatih/color"
@@ -56,6 +57,9 @@ func (devFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	coloredPrintf := logLevelToPrintfFunction(entry.Level)
 	for i, k := range keys {
 		v := entry.Data[k]
+		if isEmptyString(v) {
+			v = `""`
+		}
 
 		buff.WriteString(coloredPrintf(k))
 		buff.WriteByte('=')
@@ -126,4 +130,9 @@ func logLevelToPrintfFunction(lvl logrus.Level) func(format string, a ...interfa
 	default:
 		return color.New().Sprintf
 	}
+}
+
+func isEmptyString(i interface{}) bool {
+	v := reflect.ValueOf(i)
+	return v.Kind() == reflect.String && v.String() == ""
 }

--- a/internal/logger/dev_format.go
+++ b/internal/logger/dev_format.go
@@ -1,0 +1,129 @@
+package logger
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/fatih/color"
+	"github.com/sirupsen/logrus"
+
+	"github.com/ShoshinNikita/budget-manager/internal/pkg/caller"
+)
+
+// {year}-{month}-{day} {hour}:{minute}:{second}
+const timeLayout = "2006-01-02 15:04:05"
+
+// devFormatter is used as a log formatter in the developer mode
+type devFormatter struct{}
+
+var _ logrus.Formatter = devFormatter{}
+
+// Format formats '*logrus.Entry'
+func (devFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	buff := &bytes.Buffer{}
+	if entry.Buffer != nil {
+		buff = entry.Buffer
+	}
+
+	// Time
+	buff.WriteString(color.HiGreenString(entry.Time.Format(timeLayout)))
+	buff.WriteByte(' ')
+
+	// Level
+	buff.Write(logLevelToString(entry.Level))
+	buff.WriteByte(' ')
+
+	// Message
+	buff.WriteString(entry.Message)
+	buff.WriteByte(' ')
+
+	// Fields
+
+	// Add the caller to fields
+	if entry.HasCaller() {
+		entry.Data["func"] = caller.FormatCaller(entry.Caller.Func)
+	}
+
+	// Sort field keys
+	keys := make([]string, 0, len(entry.Data))
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Write
+	coloredPrintf := logLevelToPrintfFunction(entry.Level)
+	for i, k := range keys {
+		v := entry.Data[k]
+
+		buff.WriteString(coloredPrintf(k))
+		buff.WriteByte('=')
+		fmt.Fprint(buff, v)
+		if i+1 != len(keys) {
+			buff.WriteByte(' ')
+		}
+	}
+
+	buff.WriteByte('\n')
+	return buff.Bytes(), nil
+}
+
+// Ready to print colored log levels
+//
+//nolint:gochecknoglobals
+var (
+	coloredTraceLvl = []byte(color.HiMagentaString("[TRC]"))
+	coloredDebugLvl = []byte(color.HiMagentaString("[DBG]"))
+	coloredInfoLvl  = []byte(color.CyanString("[INF]"))
+	coloredWarnLvl  = []byte(color.YellowString("[WRN]"))
+	coloredErrLvl   = []byte(color.RedString("[ERR]"))
+	coloredPanicLvl = []byte(color.New(color.BgRed).Sprint("[PNC]"))
+	coloredFatalLvl = []byte(color.New(color.BgRed).Sprint("[FAT]"))
+)
+
+// logLevelToString converts logrus log level to colored string
+// It returns bytes for greater convenience
+func logLevelToString(lvl logrus.Level) []byte {
+	switch lvl {
+	case logrus.TraceLevel:
+		return coloredTraceLvl
+	case logrus.DebugLevel:
+		return coloredDebugLvl
+	case logrus.InfoLevel:
+		return coloredInfoLvl
+	case logrus.WarnLevel:
+		return coloredWarnLvl
+	case logrus.ErrorLevel:
+		return coloredErrLvl
+	case logrus.PanicLevel:
+		return coloredPanicLvl
+	case logrus.FatalLevel:
+		return coloredFatalLvl
+	default:
+		return []byte("[...]")
+	}
+}
+
+// logLevelToPrintfFunction returns a function to print colored output according to
+// passed logrus log level
+func logLevelToPrintfFunction(lvl logrus.Level) func(format string, a ...interface{}) string {
+	switch lvl {
+	case logrus.TraceLevel:
+		return color.YellowString
+	case logrus.DebugLevel:
+		return color.HiMagentaString
+	case logrus.InfoLevel:
+		return color.CyanString
+	case logrus.WarnLevel:
+		return color.YellowString
+	case logrus.ErrorLevel:
+		return color.RedString
+	case logrus.FatalLevel:
+		return color.New(color.BgRed).Sprintf
+	case logrus.PanicLevel:
+		return color.New(color.BgRed).Sprintf
+	default:
+		return color.New().Sprintf
+	}
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -106,6 +106,8 @@ func (l logger) WithError(err error) Logger {
 }
 
 func (l logger) WithRequest(req models.Request) Logger {
-	// TODO
-	return logger{l.FieldLogger.WithField("req", req)}
+	if fields := structToFields(req); len(fields) != 0 {
+		return l.WithFields(fields)
+	}
+	return l
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -106,7 +106,7 @@ func (l logger) WithError(err error) Logger {
 }
 
 func (l logger) WithRequest(req models.Request) Logger {
-	if fields := structToFields(req); len(fields) != 0 {
+	if fields := structToFields(req, "req"); len(fields) != 0 {
 		return l.WithFields(fields)
 	}
 	return l

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,19 +1,12 @@
 package logger
 
 import (
-	"bytes"
-	"fmt"
 	"runtime"
-	"sort"
 
-	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
 
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/caller"
 )
-
-// {year}-{month}-{day} {hour}:{minute}:{second}
-const timeLayout = "2006-01-02 15:04:05"
 
 type Config struct {
 	Debug bool `env:"DEBUG" envDefault:"false"`
@@ -71,119 +64,5 @@ func logLevelFromString(lvl string) logrus.Level {
 		return logrus.FatalLevel
 	default:
 		return logrus.InfoLevel
-	}
-}
-
-// devFormatter is used as a log formatter in the developer mode
-type devFormatter struct{}
-
-var _ logrus.Formatter = devFormatter{}
-
-// Format formats '*logrus.Entry'
-func (devFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	buff := &bytes.Buffer{}
-	if entry.Buffer != nil {
-		buff = entry.Buffer
-	}
-
-	// Time
-	buff.WriteString(color.HiGreenString(entry.Time.Format(timeLayout)))
-	buff.WriteByte(' ')
-
-	// Level
-	buff.Write(logLevelToString(entry.Level))
-	buff.WriteByte(' ')
-
-	// Message
-	buff.WriteString(entry.Message)
-	buff.WriteByte(' ')
-
-	// Fields
-
-	// Add the caller to fields
-	if entry.HasCaller() {
-		entry.Data["func"] = caller.FormatCaller(entry.Caller.Func)
-	}
-
-	// Sort field keys
-	keys := make([]string, 0, len(entry.Data))
-	for k := range entry.Data {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	// Write
-	coloredPrintf := logLevelToPrintfFunction(entry.Level)
-	for i, k := range keys {
-		v := entry.Data[k]
-
-		buff.WriteString(coloredPrintf(k))
-		buff.WriteByte('=')
-		fmt.Fprint(buff, v)
-		if i+1 != len(keys) {
-			buff.WriteByte(' ')
-		}
-	}
-
-	buff.WriteByte('\n')
-	return buff.Bytes(), nil
-}
-
-// Ready to print colored log levels
-//
-//nolint:gochecknoglobals
-var (
-	coloredTraceLvl = []byte(color.HiMagentaString("[TRC]"))
-	coloredDebugLvl = []byte(color.HiMagentaString("[DBG]"))
-	coloredInfoLvl  = []byte(color.CyanString("[INF]"))
-	coloredWarnLvl  = []byte(color.YellowString("[WRN]"))
-	coloredErrLvl   = []byte(color.RedString("[ERR]"))
-	coloredPanicLvl = []byte(color.New(color.BgRed).Sprint("[PNC]"))
-	coloredFatalLvl = []byte(color.New(color.BgRed).Sprint("[FAT]"))
-)
-
-// logLevelToString converts logrus log level to colored string
-// It returns bytes for greater convenience
-func logLevelToString(lvl logrus.Level) []byte {
-	switch lvl {
-	case logrus.TraceLevel:
-		return coloredTraceLvl
-	case logrus.DebugLevel:
-		return coloredDebugLvl
-	case logrus.InfoLevel:
-		return coloredInfoLvl
-	case logrus.WarnLevel:
-		return coloredWarnLvl
-	case logrus.ErrorLevel:
-		return coloredErrLvl
-	case logrus.PanicLevel:
-		return coloredPanicLvl
-	case logrus.FatalLevel:
-		return coloredFatalLvl
-	default:
-		return []byte("[...]")
-	}
-}
-
-// logLevelToPrintfFunction returns a function to print colored output according to
-// passed logrus log level
-func logLevelToPrintfFunction(lvl logrus.Level) func(format string, a ...interface{}) string {
-	switch lvl {
-	case logrus.TraceLevel:
-		return color.YellowString
-	case logrus.DebugLevel:
-		return color.HiMagentaString
-	case logrus.InfoLevel:
-		return color.CyanString
-	case logrus.WarnLevel:
-		return color.YellowString
-	case logrus.ErrorLevel:
-		return color.RedString
-	case logrus.FatalLevel:
-		return color.New(color.BgRed).Sprintf
-	case logrus.PanicLevel:
-		return color.New(color.BgRed).Sprintf
-	default:
-		return color.New().Sprintf
 	}
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -6,12 +6,14 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/caller"
+	"github.com/ShoshinNikita/budget-manager/internal/web/api/models"
 )
 
 type Logger interface {
 	WithField(key string, value interface{}) Logger
 	WithFields(fields Fields) Logger
 	WithError(err error) Logger
+	WithRequest(models.Request) Logger
 
 	Debug(args ...interface{})
 	Debugf(format string, args ...interface{})
@@ -101,4 +103,9 @@ func (l logger) WithFields(fields Fields) Logger {
 
 func (l logger) WithError(err error) Logger {
 	return logger{l.FieldLogger.WithError(err)}
+}
+
+func (l logger) WithRequest(req models.Request) Logger {
+	// TODO
+	return logger{l.FieldLogger.WithField("req", req)}
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -44,7 +44,7 @@ type Config struct {
 
 func New(cnf Config) Logger {
 	log := logrus.New()
-	log.SetReportCaller(true)
+	log.SetReportCaller(false)
 
 	logLevel := parseLogLevel(cnf.Level)
 	if cnf.Debug {

--- a/internal/logger/struct.go
+++ b/internal/logger/struct.go
@@ -1,0 +1,104 @@
+package logger
+
+import (
+	"fmt"
+	"go/token"
+	"reflect"
+	"time"
+)
+
+//nolint:gochecknoglobals
+var fmtStringer = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+
+// structToFields maps fields of a passed structure to Fields. It returns empty fields
+// for a non-structure arguments.
+func structToFields(i interface{}) (fields Fields) {
+	defer func() {
+		if r := recover(); r != nil {
+			fields = Fields{"struct_to_fields_panic": r, "type": fmt.Sprintf("%T", i)}
+		}
+	}()
+
+	v := deref(reflect.ValueOf(i))
+	if v.Kind() != reflect.Struct {
+		return nil
+	}
+	t := v.Type()
+
+	fieldCount := v.NumField()
+	fields = make(Fields, fieldCount)
+	for i := 0; i < fieldCount; i++ {
+		name, skip := getName(t.Field(i))
+		if skip {
+			continue
+		}
+
+		var value interface{}
+
+		f := v.Field(i)
+
+		// Check whether the field implements 'fmt.Stringer' before 'deref' call
+		// because 'String' method can be declared with a pointer receiver.
+		if f.Type().Implements(fmtStringer) && (f.Kind() != reflect.Ptr || !f.IsNil()) {
+			value = f.Interface().(fmt.Stringer).String()
+		}
+
+		f = deref(f)
+		switch f := f.Interface().(type) { //nolint:gocritic
+		case time.Time:
+			value = f.Format(time.RFC3339)
+		}
+
+		if value != nil {
+			fields[name] = value
+			continue
+		}
+
+		// Fallback to basic types
+		switch f.Kind() { //nolint:exhaustive
+		case
+			reflect.Bool,
+			reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+			reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+			reflect.Float32, reflect.Float64,
+			reflect.Complex64, reflect.Complex128,
+			reflect.String,
+			reflect.Array:
+
+			fields[name] = f.Interface()
+
+		case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Interface:
+			var value interface{} = "<nil>"
+			if !f.IsNil() {
+				value = f.Interface()
+			}
+			fields[name] = value
+
+		case reflect.Struct:
+			for k, v := range structToFields(f.Interface()) {
+				fields[name+"."+k] = v
+			}
+		}
+	}
+	return fields
+}
+
+func getName(f reflect.StructField) (name string, skip bool) {
+	if !token.IsExported(f.Name) {
+		return "", true
+	}
+	name = f.Name
+	if v := f.Tag.Get("json"); v != "" {
+		name = v
+	}
+	return name, false
+}
+
+// deref returns a pointer's value, traversing as many levels as needed
+// until Value's kind is not reflect.Ptr or Value.IsNil returns true.
+func deref(v reflect.Value) reflect.Value {
+	for v.Kind() == reflect.Ptr && !v.IsNil() {
+		v = v.Elem()
+	}
+	return v
+}

--- a/internal/logger/struct_test.go
+++ b/internal/logger/struct_test.go
@@ -12,14 +12,15 @@ func TestStructToFields(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		in   interface{}
-		want Fields
+		in         interface{}
+		namePrefix string
+		want       Fields
 	}
 	runTestCases := func(t *testing.T, testCases []testCase) {
 		for _, tt := range testCases {
 			tt := tt
 			t.Run("", func(t *testing.T) {
-				got := structToFields(tt.in)
+				got := structToFields(tt.in, tt.namePrefix)
 				require.Equal(t, tt.want, got)
 			})
 		}
@@ -55,8 +56,9 @@ func TestStructToFields(t *testing.T) {
 				want: Fields{"a": 0.15, "b": "hello world", "C": map[string]float64{"1": 2}, "e": 10, "F": "<nil>"},
 			},
 			{
-				in:   S{A: 0, B: "", E: &iPtr},
-				want: Fields{"a": 0.0, "b": "", "C": "<nil>", "e": 10, "F": "<nil>"},
+				in:         S{A: 0, B: "", E: &iPtr},
+				namePrefix: "p",
+				want:       Fields{"p.a": 0.0, "p.b": "", "p.C": "<nil>", "p.e": 10, "p.F": "<nil>"},
 			},
 		})
 	})
@@ -88,8 +90,9 @@ func TestStructToFields(t *testing.T) {
 
 		runTestCases(t, []testCase{
 			{
-				in:   S{Embedded: Embedded{A: 1, B: 2}, A: "qwerty", Nested: Nested{X: 3}},
-				want: Fields{"Embedded.a": 1, "Embedded.b": 2, "a": "qwerty", "nested.x": 3, "nested.nested1.arr": "<nil>"},
+				in:         S{Embedded: Embedded{A: 1, B: 2}, A: "qwerty", Nested: Nested{X: 3}},
+				namePrefix: "req",
+				want:       Fields{"req.Embedded.a": 1, "req.Embedded.b": 2, "req.a": "qwerty", "req.nested.x": 3, "req.nested.nested1.arr": "<nil>"},
 			},
 		})
 	})

--- a/internal/logger/struct_test.go
+++ b/internal/logger/struct_test.go
@@ -1,0 +1,129 @@
+package logger
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStructToFields(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		in   interface{}
+		want Fields
+	}
+	runTestCases := func(t *testing.T, testCases []testCase) {
+		for _, tt := range testCases {
+			tt := tt
+			t.Run("", func(t *testing.T) {
+				got := structToFields(tt.in)
+				require.Equal(t, tt.want, got)
+			})
+		}
+	}
+
+	t.Run("wrong types", func(t *testing.T) {
+		runTestCases(t, []testCase{
+			{in: 5, want: nil},
+			{in: 15.7, want: nil},
+			{in: "hello", want: nil},
+			{in: func() error { return nil }, want: nil},
+			{in: map[string]int{"1": 2}, want: nil},
+		})
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		type S struct {
+			A float64 `json:"a"`
+			B string  `json:"b"`
+			C map[string]float64
+			E **int `json:"e"`
+			F *float64
+			g string
+		}
+
+		var (
+			i    = 10
+			iPtr = &i
+		)
+		runTestCases(t, []testCase{
+			{
+				in:   S{A: 0.15, B: "hello world", C: map[string]float64{"1": 2}, E: &iPtr, F: nil, g: "g"},
+				want: Fields{"a": 0.15, "b": "hello world", "C": map[string]float64{"1": 2}, "e": 10, "F": "<nil>"},
+			},
+			{
+				in:   S{A: 0, B: "", E: &iPtr},
+				want: Fields{"a": 0.0, "b": "", "C": "<nil>", "e": 10, "F": "<nil>"},
+			},
+		})
+	})
+
+	t.Run("complex", func(t *testing.T) {
+		type Embedded struct {
+			A int `json:"a"`
+			B int `json:"b"`
+		}
+
+		type Empty struct{}
+
+		type Nested1 struct {
+			Arr []string `json:"arr"`
+		}
+
+		type Nested struct {
+			X      int     `json:"x"`
+			Nested Nested1 `json:"nested1"`
+		}
+
+		type S struct {
+			Embedded
+			Empty
+
+			A      string `json:"a"`
+			Nested Nested `json:"nested"`
+		}
+
+		runTestCases(t, []testCase{
+			{
+				in:   S{Embedded: Embedded{A: 1, B: 2}, A: "qwerty", Nested: Nested{X: 3}},
+				want: Fields{"Embedded.a": 1, "Embedded.b": 2, "a": "qwerty", "nested.x": 3, "nested.nested1.arr": "<nil>"},
+			},
+		})
+	})
+
+	t.Run("format", func(t *testing.T) {
+		type S struct {
+			T time.Time        `json:"t"`
+			D time.Duration    `json:"d"`
+			B *strings.Builder `json:"b"` // (*strings.Builder).String() panics if builder is nil
+		}
+
+		runTestCases(t, []testCase{
+			{
+				in: S{
+					T: time.Date(2021, time.August, 11, 0, 0, 0, 0, time.UTC),
+					D: 5 * time.Second,
+				},
+				want: Fields{
+					"t": "2021-08-11T00:00:00Z",
+					"d": "5s",
+					"b": "<nil>",
+				},
+			},
+			{
+				in: S{
+					T: time.Date(2021, time.August, 11, 0, 0, 0, 0, time.UTC),
+					B: &strings.Builder{},
+				},
+				want: Fields{
+					"t": "2021-08-11T00:00:00Z",
+					"d": "0s",
+					"b": "",
+				},
+			},
+		})
+	})
+}

--- a/internal/pkg/reqid/request_id.go
+++ b/internal/pkg/reqid/request_id.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 
-	"github.com/sirupsen/logrus"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 )
 
 // RequestID is a random hex string. It doesn't correspond to UUID RFC 4122 format because it would be
@@ -44,7 +44,7 @@ func ToContext(ctx context.Context, reqID RequestID) context.Context {
 const loggerFieldKey = "request_id"
 
 // FromContextToLogger extracts request id from context and returns logger with added field
-func FromContextToLogger(ctx context.Context, log logrus.FieldLogger) *logrus.Entry {
+func FromContextToLogger(ctx context.Context, log logger.Logger) logger.Logger {
 	reqID := FromContext(ctx)
 	return log.WithField(loggerFieldKey, reqID)
 }

--- a/internal/web/api/api.go
+++ b/internal/web/api/api.go
@@ -1,6 +1,6 @@
 package api
 
-import "github.com/sirupsen/logrus"
+import "github.com/ShoshinNikita/budget-manager/internal/logger"
 
 type Handlers struct {
 	MonthsHandlers
@@ -20,7 +20,7 @@ type DB interface {
 	SearchDB
 }
 
-func NewHandlers(db DB, log logrus.FieldLogger) *Handlers {
+func NewHandlers(db DB, log logger.Logger) *Handlers {
 	return &Handlers{
 		MonthsHandlers:          MonthsHandlers{db: db, log: log},
 		IncomesHandlers:         IncomesHandlers{db: db, log: log},

--- a/internal/web/api/income.go
+++ b/internal/web/api/income.go
@@ -44,13 +44,9 @@ func (h IncomesHandlers) AddIncome(w http.ResponseWriter, r *http.Request) {
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{
-		"month_id": req.MonthID, "title": req.Title, "notes": req.Notes, "income": req.Income,
-	})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("add Income")
 	args := db.AddIncomeArgs{
 		MonthID: req.MonthID,
 		Title:   req.Title,
@@ -68,7 +64,7 @@ func (h IncomesHandlers) AddIncome(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log = log.WithField("id", id)
-	log.Info("Income was successfully added")
+	log.Debug("Income was successfully added")
 
 	// Encode
 	w.WriteHeader(http.StatusCreated)
@@ -102,13 +98,9 @@ func (h IncomesHandlers) EditIncome(w http.ResponseWriter, r *http.Request) {
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{
-		"id": req.ID, "title": req.Title, "notes": req.Notes, "income": req.Income,
-	})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("edit Income")
 	args := db.EditIncomeArgs{
 		ID:    req.ID,
 		Title: req.Title,
@@ -128,7 +120,7 @@ func (h IncomesHandlers) EditIncome(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	log.Info("Income was successfully edited")
+	log.Debug("Income was successfully edited")
 
 	// Encode
 	resp := models.Response{
@@ -158,11 +150,9 @@ func (h IncomesHandlers) RemoveIncome(w http.ResponseWriter, r *http.Request) {
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithField("id", req.ID)
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("remove Income")
 	err := h.db.RemoveIncome(ctx, req.ID)
 	if err != nil {
 		switch {
@@ -173,7 +163,7 @@ func (h IncomesHandlers) RemoveIncome(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	log.Info("Income was successfully removed")
+	log.Debug("Income was successfully removed")
 
 	// Encode
 	resp := models.Response{

--- a/internal/web/api/income.go
+++ b/internal/web/api/income.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/ShoshinNikita/budget-manager/internal/db"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/money"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/api/models"
@@ -16,7 +15,7 @@ import (
 
 type IncomesHandlers struct {
 	db  IncomesDB
-	log logrus.FieldLogger
+	log logger.Logger
 }
 
 type IncomesDB interface {
@@ -46,7 +45,7 @@ func (h IncomesHandlers) AddIncome(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{
+	log = log.WithFields(logger.Fields{
 		"month_id": req.MonthID, "title": req.Title, "notes": req.Notes, "income": req.Income,
 	})
 
@@ -104,7 +103,7 @@ func (h IncomesHandlers) EditIncome(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{
+	log = log.WithFields(logger.Fields{
 		"id": req.ID, "title": req.Title, "notes": req.Notes, "income": req.Income,
 	})
 

--- a/internal/web/api/models/income.go
+++ b/internal/web/api/models/income.go
@@ -1,7 +1,7 @@
 package models
 
 type AddIncomeReq struct {
-	Request
+	BaseRequest
 
 	MonthID uint    `json:"month_id" validate:"required" example:"1"`
 	Title   string  `json:"title" validate:"required" example:"Salary"`
@@ -33,7 +33,7 @@ type AddIncomeResp struct {
 }
 
 type EditIncomeReq struct {
-	Request
+	BaseRequest
 
 	ID     uint     `json:"id" validate:"required" example:"1"`
 	Title  *string  `json:"title"`
@@ -59,7 +59,7 @@ func (req *EditIncomeReq) SanitizeAndCheck() error {
 }
 
 type RemoveIncomeReq struct {
-	Request
+	BaseRequest
 
 	ID uint `json:"id" validate:"required" example:"1"`
 }

--- a/internal/web/api/models/models.go
+++ b/internal/web/api/models/models.go
@@ -8,8 +8,16 @@ import (
 	"github.com/ShoshinNikita/budget-manager/internal/db"
 )
 
-// Request is a base request model that must be nested into all requests
-type Request struct{}
+// All requests implement the Request interface
+type Request interface {
+	request()
+}
+
+// BaseRequest is a base request model that implements Request interface.
+// It must be nested into all requests
+type BaseRequest struct{}
+
+func (BaseRequest) request() {}
 
 // Response is a base response model that must be nested into all responses
 type Response struct {
@@ -24,7 +32,7 @@ type Response struct {
 // -------------------------------------------------
 
 type GetMonthByDateReq struct {
-	Request
+	BaseRequest
 
 	Year  int        `json:"year" validate:"required" example:"2020"`
 	Month time.Month `json:"month" validate:"required" swaggertype:"integer" example:"7"`

--- a/internal/web/api/models/monthly_payment.go
+++ b/internal/web/api/models/monthly_payment.go
@@ -1,7 +1,7 @@
 package models
 
 type AddMonthlyPaymentReq struct {
-	Request
+	BaseRequest
 
 	MonthID uint `json:"month_id" validate:"required" example:"1"`
 
@@ -36,7 +36,7 @@ type AddMonthlyPaymentResp struct {
 }
 
 type EditMonthlyPaymentReq struct {
-	Request
+	BaseRequest
 
 	ID     uint     `json:"id" validate:"required" example:"1"`
 	Title  *string  `json:"title"`
@@ -64,7 +64,7 @@ func (req *EditMonthlyPaymentReq) SanitizeAndCheck() error {
 }
 
 type RemoveMonthlyPaymentReq struct {
-	Request
+	BaseRequest
 
 	ID uint `json:"id" validate:"required" example:"1"`
 }

--- a/internal/web/api/models/search.go
+++ b/internal/web/api/models/search.go
@@ -9,7 +9,7 @@ import (
 
 // SearchSpendsReq is used to search for spends
 type SearchSpendsReq struct {
-	Request
+	BaseRequest
 
 	// Title can be in any case. Search will be performed by lowercased value
 	Title string `json:"title"`

--- a/internal/web/api/models/spend.go
+++ b/internal/web/api/models/spend.go
@@ -1,7 +1,7 @@
 package models
 
 type AddSpendReq struct {
-	Request
+	BaseRequest
 
 	DayID uint `json:"day_id" validate:"required" example:"1"`
 
@@ -36,7 +36,7 @@ type AddSpendResp struct {
 }
 
 type EditSpendReq struct {
-	Request
+	BaseRequest
 
 	ID     uint     `json:"id" validate:"required" example:"1"`
 	Title  *string  `json:"title"`
@@ -64,7 +64,7 @@ func (req *EditSpendReq) SanitizeAndCheck() error {
 }
 
 type RemoveSpendReq struct {
-	Request
+	BaseRequest
 
 	ID uint `json:"id" validate:"required" example:"1"`
 }

--- a/internal/web/api/models/spend_type.go
+++ b/internal/web/api/models/spend_type.go
@@ -11,7 +11,7 @@ type GetSpendTypesResp struct {
 }
 
 type AddSpendTypeReq struct {
-	Request
+	BaseRequest
 
 	Name     string `json:"name" validate:"required" example:"Food"`
 	ParentID uint   `json:"parent_id"`
@@ -33,7 +33,7 @@ type AddSpendTypeResp struct {
 }
 
 type EditSpendTypeReq struct {
-	Request
+	BaseRequest
 
 	ID       uint    `json:"id" validate:"required" example:"1"`
 	Name     *string `json:"name" example:"Vegetables"`
@@ -53,7 +53,7 @@ func (req *EditSpendTypeReq) SanitizeAndCheck() error {
 }
 
 type RemoveSpendTypeReq struct {
-	Request
+	BaseRequest
 
 	ID uint `json:"id" validate:"required" example:"1"`
 }

--- a/internal/web/api/month.go
+++ b/internal/web/api/month.go
@@ -6,9 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/ShoshinNikita/budget-manager/internal/db"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/api/models"
 	"github.com/ShoshinNikita/budget-manager/internal/web/utils"
@@ -16,7 +15,7 @@ import (
 
 type MonthsHandlers struct {
 	db  MonthsDB
-	log logrus.FieldLogger
+	log logger.Logger
 }
 
 type MonthsDB interface {
@@ -43,7 +42,7 @@ func (h MonthsHandlers) GetMonthByDate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{"year": req.Year, "month": req.Month})
+	log = log.WithFields(logger.Fields{"year": req.Year, "month": req.Month})
 
 	// Process
 	log.Debug("get month from the database")

--- a/internal/web/api/month.go
+++ b/internal/web/api/month.go
@@ -41,11 +41,9 @@ func (h MonthsHandlers) GetMonthByDate(w http.ResponseWriter, r *http.Request) {
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{"year": req.Year, "month": req.Month})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("get month from the database")
 	month, err := h.db.GetMonthByDate(ctx, req.Year, req.Month)
 	if err != nil {
 		switch {

--- a/internal/web/api/monthly_payment.go
+++ b/internal/web/api/monthly_payment.go
@@ -44,14 +44,9 @@ func (h MonthlyPaymentsHandlers) AddMonthlyPayment(w http.ResponseWriter, r *htt
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{
-		"month_id": req.MonthID, "title": req.Title, "type_id": req.TypeID,
-		"notes": req.Notes, "cost": req.Cost,
-	})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("add Monthly Payment")
 	args := db.AddMonthlyPaymentArgs{
 		MonthID: req.MonthID,
 		Title:   req.Title,
@@ -72,7 +67,7 @@ func (h MonthlyPaymentsHandlers) AddMonthlyPayment(w http.ResponseWriter, r *htt
 		return
 	}
 	log = log.WithField("id", id)
-	log.Info("Monthly Payment was successfully added")
+	log.Debug("Monthly Payment was successfully added")
 
 	// Encode
 	w.WriteHeader(http.StatusCreated)
@@ -106,13 +101,9 @@ func (h MonthlyPaymentsHandlers) EditMonthlyPayment(w http.ResponseWriter, r *ht
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{
-		"id": req.ID, "title": req.Title, "notes": req.Notes, "type_id": req.TypeID, "cost": req.Cost,
-	})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("edit Monthly Payment")
 	args := db.EditMonthlyPaymentArgs{
 		ID:     req.ID,
 		Title:  req.Title,
@@ -135,7 +126,7 @@ func (h MonthlyPaymentsHandlers) EditMonthlyPayment(w http.ResponseWriter, r *ht
 		}
 		return
 	}
-	log.Info("Monthly Payment was successfully edited")
+	log.Debug("Monthly Payment was successfully edited")
 
 	// Encode
 	resp := models.Response{
@@ -165,11 +156,9 @@ func (h MonthlyPaymentsHandlers) RemoveMonthlyPayment(w http.ResponseWriter, r *
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithField("id", req.ID)
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("remove Monthly Payment")
 	err := h.db.RemoveMonthlyPayment(ctx, req.ID)
 	if err != nil {
 		switch {
@@ -180,7 +169,7 @@ func (h MonthlyPaymentsHandlers) RemoveMonthlyPayment(w http.ResponseWriter, r *
 		}
 		return
 	}
-	log.Info("Monthly Payment was successfully removed")
+	log.Debug("Monthly Payment was successfully removed")
 
 	// Encode
 	resp := models.Response{

--- a/internal/web/api/monthly_payment.go
+++ b/internal/web/api/monthly_payment.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/ShoshinNikita/budget-manager/internal/db"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/money"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/api/models"
@@ -16,7 +15,7 @@ import (
 
 type MonthlyPaymentsHandlers struct {
 	db  MonthlyPaymentsDB
-	log logrus.FieldLogger
+	log logger.Logger
 }
 
 type MonthlyPaymentsDB interface {
@@ -46,7 +45,7 @@ func (h MonthlyPaymentsHandlers) AddMonthlyPayment(w http.ResponseWriter, r *htt
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{
+	log = log.WithFields(logger.Fields{
 		"month_id": req.MonthID, "title": req.Title, "type_id": req.TypeID,
 		"notes": req.Notes, "cost": req.Cost,
 	})
@@ -108,7 +107,7 @@ func (h MonthlyPaymentsHandlers) EditMonthlyPayment(w http.ResponseWriter, r *ht
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{
+	log = log.WithFields(logger.Fields{
 		"id": req.ID, "title": req.Title, "notes": req.Notes, "type_id": req.TypeID, "cost": req.Cost,
 	})
 

--- a/internal/web/api/search.go
+++ b/internal/web/api/search.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/ShoshinNikita/budget-manager/internal/db"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/money"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/api/models"
@@ -16,7 +15,7 @@ import (
 
 type SearchHandlers struct {
 	db  SearchDB
-	log logrus.FieldLogger
+	log logger.Logger
 }
 
 type SearchDB interface {
@@ -42,7 +41,7 @@ func (h SearchHandlers) SearchSpends(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{
+	log = log.WithFields(logger.Fields{
 		"title": req.Title, "title_exactly": req.TitleExactly,
 		"notes": req.Notes, "notes_exactly": req.NotesExactly,
 		"after": req.After, "before": req.Before, "type_ids": req.TypeIDs,

--- a/internal/web/api/search.go
+++ b/internal/web/api/search.go
@@ -40,17 +40,9 @@ func (h SearchHandlers) SearchSpends(w http.ResponseWriter, r *http.Request) {
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{
-		"title": req.Title, "title_exactly": req.TitleExactly,
-		"notes": req.Notes, "notes_exactly": req.NotesExactly,
-		"after": req.After, "before": req.Before, "type_ids": req.TypeIDs,
-		"min_cost": req.MinCost, "max_cost": req.MaxCost,
-		"sort": req.Sort, "order": req.Order,
-	})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("search for Spends")
 	args := db.SearchSpendsArgs{
 		Title:        strings.ToLower(req.Title),
 		Notes:        strings.ToLower(req.Notes),

--- a/internal/web/api/spend.go
+++ b/internal/web/api/spend.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/ShoshinNikita/budget-manager/internal/db"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/money"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/api/models"
@@ -16,7 +15,7 @@ import (
 
 type SpendsHandlers struct {
 	db  SpendsDB
-	log logrus.FieldLogger
+	log logger.Logger
 }
 
 type SpendsDB interface {
@@ -46,7 +45,7 @@ func (h SpendsHandlers) AddSpend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{
+	log = log.WithFields(logger.Fields{
 		"day_id": req.DayID, "title": req.Title, "type_id": req.TypeID,
 		"notes": req.Notes, "cost": req.Cost,
 	})
@@ -108,7 +107,7 @@ func (h SpendsHandlers) EditSpend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{
+	log = log.WithFields(logger.Fields{
 		"id": req.ID, "title": req.Title, "notes": req.Notes, "type_id": req.TypeID,
 	})
 

--- a/internal/web/api/spend.go
+++ b/internal/web/api/spend.go
@@ -44,14 +44,9 @@ func (h SpendsHandlers) AddSpend(w http.ResponseWriter, r *http.Request) {
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{
-		"day_id": req.DayID, "title": req.Title, "type_id": req.TypeID,
-		"notes": req.Notes, "cost": req.Cost,
-	})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("add Spend")
 	args := db.AddSpendArgs{
 		DayID:  req.DayID,
 		Title:  req.Title,
@@ -72,7 +67,7 @@ func (h SpendsHandlers) AddSpend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log = log.WithField("id", id)
-	log.Info("Spend was successfully added")
+	log.Debug("Spend was successfully added")
 
 	// Encode
 	w.WriteHeader(http.StatusCreated)
@@ -106,13 +101,9 @@ func (h SpendsHandlers) EditSpend(w http.ResponseWriter, r *http.Request) {
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{
-		"id": req.ID, "title": req.Title, "notes": req.Notes, "type_id": req.TypeID,
-	})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("edit Spend")
 	args := db.EditSpendArgs{
 		ID:     req.ID,
 		Title:  req.Title,
@@ -135,7 +126,7 @@ func (h SpendsHandlers) EditSpend(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	log.Info("Spend was successfully edited")
+	log.Debug("Spend was successfully edited")
 
 	// Encode
 	resp := models.Response{
@@ -165,11 +156,9 @@ func (h SpendsHandlers) RemoveSpend(w http.ResponseWriter, r *http.Request) {
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithField("id", req.ID)
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("remove Spend")
 	err := h.db.RemoveSpend(ctx, req.ID)
 	if err != nil {
 		switch {
@@ -180,7 +169,7 @@ func (h SpendsHandlers) RemoveSpend(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	log.Info("Spend was successfully removed")
+	log.Debug("Spend was successfully removed")
 
 	// Encode
 	resp := models.Response{

--- a/internal/web/api/spend_type.go
+++ b/internal/web/api/spend_type.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	"github.com/ShoshinNikita/budget-manager/internal/db"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/api/models"
 	"github.com/ShoshinNikita/budget-manager/internal/web/utils"
@@ -15,7 +15,7 @@ import (
 
 type SpendTypesHandlers struct {
 	db  SpendTypesDB
-	log logrus.FieldLogger
+	log logger.Logger
 }
 
 type SpendTypesDB interface {
@@ -75,7 +75,7 @@ func (h SpendTypesHandlers) AddSpendType(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{"name": req.Name, "parent_id": req.ParentID})
+	log = log.WithFields(logger.Fields{"name": req.Name, "parent_id": req.ParentID})
 
 	// Process
 	log.Debug("add Spend Type")
@@ -124,7 +124,7 @@ func (h SpendTypesHandlers) EditSpendType(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	log = log.WithFields(logrus.Fields{"id": req.ID, "name": req.Name})
+	log = log.WithFields(logger.Fields{"id": req.ID, "name": req.Name})
 
 	if req.ParentID != nil && *req.ParentID != 0 {
 		allSpendTypes, err := h.db.GetSpendTypes(ctx)

--- a/internal/web/api/spend_type.go
+++ b/internal/web/api/spend_type.go
@@ -37,7 +37,6 @@ func (h SpendTypesHandlers) GetSpendTypes(w http.ResponseWriter, r *http.Request
 	log := reqid.FromContextToLogger(ctx, h.log)
 
 	// Process
-	log.Debug("return all Spend Types")
 	types, err := h.db.GetSpendTypes(ctx)
 	if err != nil {
 		utils.ProcessInternalError(ctx, log, w, "couldn't get Spend Types", err)
@@ -74,11 +73,9 @@ func (h SpendTypesHandlers) AddSpendType(w http.ResponseWriter, r *http.Request)
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{"name": req.Name, "parent_id": req.ParentID})
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("add Spend Type")
 	args := db.AddSpendTypeArgs{
 		Name:     req.Name,
 		ParentID: req.ParentID,
@@ -89,7 +86,7 @@ func (h SpendTypesHandlers) AddSpendType(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	log = log.WithField("id", id)
-	log.Info("Spend Type was successfully added")
+	log.Debug("Spend Type was successfully added")
 
 	// Encode
 	w.WriteHeader(http.StatusCreated)
@@ -123,8 +120,7 @@ func (h SpendTypesHandlers) EditSpendType(w http.ResponseWriter, r *http.Request
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithFields(logger.Fields{"id": req.ID, "name": req.Name})
+	log = log.WithRequest(req)
 
 	if req.ParentID != nil && *req.ParentID != 0 {
 		allSpendTypes, err := h.db.GetSpendTypes(ctx)
@@ -146,8 +142,6 @@ func (h SpendTypesHandlers) EditSpendType(w http.ResponseWriter, r *http.Request
 	}
 
 	// Process
-	log.Debug("edit Spend Type")
-
 	args := db.EditSpendTypeArgs{
 		ID:       req.ID,
 		Name:     req.Name,
@@ -163,7 +157,7 @@ func (h SpendTypesHandlers) EditSpendType(w http.ResponseWriter, r *http.Request
 		}
 		return
 	}
-	log.Info("Spend Type was successfully edited")
+	log.Debug("Spend Type was successfully edited")
 
 	// Encode
 	resp := models.Response{
@@ -221,11 +215,9 @@ func (h SpendTypesHandlers) RemoveSpendType(w http.ResponseWriter, r *http.Reque
 	if ok := utils.DecodeRequest(w, r, log, req); !ok {
 		return
 	}
-
-	log = log.WithField("id", req.ID)
+	log = log.WithRequest(req)
 
 	// Process
-	log.Debug("remove Spend Type")
 	err := h.db.RemoveSpendType(ctx, req.ID)
 	if err != nil {
 		switch {
@@ -236,7 +228,7 @@ func (h SpendTypesHandlers) RemoveSpendType(w http.ResponseWriter, r *http.Reque
 		}
 		return
 	}
-	log.Info("Spend Type was successfully removed")
+	log.Debug("Spend Type was successfully removed")
 
 	// Encode
 	resp := models.Response{

--- a/internal/web/midllewares.go
+++ b/internal/web/midllewares.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	auth "github.com/abbot/go-http-auth"
-	"github.com/sirupsen/logrus"
 
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 )
 
@@ -22,7 +22,7 @@ func (s Server) basicAuthMiddleware(h http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		log := reqid.FromContextToLogger(r.Context(), s.log)
-		log = log.WithFields(logrus.Fields{"ip": r.RemoteAddr})
+		log = log.WithFields(logger.Fields{"ip": r.RemoteAddr})
 
 		if username := basicAuthenticator.CheckAuth(r); username == "" {
 			// Auth has failed
@@ -82,7 +82,7 @@ func (s Server) loggingMiddleware(h http.Handler) http.Handler {
 		}
 
 		log := reqid.FromContextToLogger(r.Context(), s.log)
-		log = log.WithFields(logrus.Fields{"method": r.Method, "url": r.URL.Path})
+		log = log.WithFields(logger.Fields{"method": r.Method, "url": r.URL.Path})
 
 		log.Debug("start request")
 
@@ -91,7 +91,7 @@ func (s Server) loggingMiddleware(h http.Handler) http.Handler {
 		h.ServeHTTP(respWriter, r)
 		since := time.Since(now)
 
-		log.WithFields(logrus.Fields{
+		log.WithFields(logger.Fields{
 			"time":           since,
 			"status_code":    respWriter.statusCode,
 			"content_length": respWriter.contentLength,

--- a/internal/web/pages/pages.go
+++ b/internal/web/pages/pages.go
@@ -11,9 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/ShoshinNikita/budget-manager/internal/db"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/money"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/pages/statistics"
@@ -29,7 +28,7 @@ const (
 type Handlers struct {
 	db          DB
 	tplExecutor *templateExecutor
-	log         logrus.FieldLogger
+	log         logger.Logger
 
 	version string
 	gitHash string
@@ -44,7 +43,7 @@ type DB interface {
 	SearchSpends(ctx context.Context, args db.SearchSpendsArgs) ([]db.Spend, error)
 }
 
-func NewHandlers(db DB, log logrus.FieldLogger, cacheTemplates bool, version, gitHash string) *Handlers {
+func NewHandlers(db DB, log logger.Logger, cacheTemplates bool, version, gitHash string) *Handlers {
 	return &Handlers{
 		db:          db,
 		tplExecutor: newTemplateExecutor(log, cacheTemplates, commonTemplateFuncs()),
@@ -72,7 +71,7 @@ func (h Handlers) IndexPage(w http.ResponseWriter, r *http.Request) {
 	year, month, _ := time.Now().Date()
 
 	reqid.FromContextToLogger(r.Context(), h.log).
-		WithFields(logrus.Fields{"year": year, "month": int(month)}).
+		WithFields(logger.Fields{"year": year, "month": int(month)}).
 		Debug("redirect to the current month")
 
 	url := fmt.Sprintf("/%d-%d", year, month)
@@ -366,7 +365,7 @@ func (h Handlers) SearchSpendsPage(w http.ResponseWriter, r *http.Request) {
 }
 
 //nolint:funlen
-func parseSearchSpendsArgs(r *http.Request, log logrus.FieldLogger) db.SearchSpendsArgs {
+func parseSearchSpendsArgs(r *http.Request, log logger.Logger) db.SearchSpendsArgs {
 	// Title and Notes
 	title := strings.ToLower(strings.TrimSpace(r.FormValue("title")))
 	notes := strings.ToLower(strings.TrimSpace(r.FormValue("notes")))

--- a/internal/web/pages/template_executor.go
+++ b/internal/web/pages/template_executor.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/templates"
 )
@@ -20,14 +20,14 @@ import (
 type templateExecutor struct {
 	cacheTemplates bool
 	fs             fs.ReadDirFS
-	log            logrus.FieldLogger
+	log            logger.Logger
 	commonFuncs    template.FuncMap
 
 	mu  sync.Mutex
 	tpl *template.Template
 }
 
-func newTemplateExecutor(log logrus.FieldLogger, cacheTemplates bool, commonFuncs template.FuncMap) *templateExecutor {
+func newTemplateExecutor(log logger.Logger, cacheTemplates bool, commonFuncs template.FuncMap) *templateExecutor {
 	return &templateExecutor{
 		fs:             templates.New(cacheTemplates),
 		log:            log,
@@ -88,7 +88,7 @@ func (e *templateExecutor) getCommonFuncs() template.FuncMap {
 
 // executeTemplate executes passed template. It checks for errors before writing into w: it executes
 // template into temporary buffer and copies data if everything is fine
-func executeTemplate(log logrus.FieldLogger, tpl *template.Template, w io.Writer, data interface{}) error {
+func executeTemplate(log logger.Logger, tpl *template.Template, w io.Writer, data interface{}) error {
 	buff := bytes.NewBuffer(nil)
 
 	now := time.Now()

--- a/internal/web/pages/utils.go
+++ b/internal/web/pages/utils.go
@@ -7,16 +7,16 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/sirupsen/logrus"
 
 	"github.com/ShoshinNikita/budget-manager/internal/db"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/money"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/utils"
 )
 
 // processErrorWithPage is similar to 'utils.ProcessError' but shows the error page instead of returning json
-func (h Handlers) processErrorWithPage(ctx context.Context, log logrus.FieldLogger, w http.ResponseWriter,
+func (h Handlers) processErrorWithPage(ctx context.Context, log logger.Logger, w http.ResponseWriter,
 	respMsg string, code int) {
 
 	data := struct {
@@ -42,7 +42,7 @@ func (h Handlers) processErrorWithPage(ctx context.Context, log logrus.FieldLogg
 
 // processInternalErrorWithPage is similar to 'utils.ProcessInternalError' but shows the error page
 // instead of returning json
-func (h Handlers) processInternalErrorWithPage(ctx context.Context, log logrus.FieldLogger, w http.ResponseWriter,
+func (h Handlers) processInternalErrorWithPage(ctx context.Context, log logger.Logger, w http.ResponseWriter,
 	respMsg string, err error) {
 
 	utils.LogInternalError(log, respMsg, err)

--- a/internal/web/utils/decode.go
+++ b/internal/web/utils/decode.go
@@ -6,8 +6,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/sirupsen/logrus"
-
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/web/utils/schema"
 )
 
@@ -16,7 +15,7 @@ type Request interface {
 }
 
 // DecodeRequest decodes request and checks its validity. It process error if needed
-func DecodeRequest(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger, req Request) (ok bool) {
+func DecodeRequest(w http.ResponseWriter, r *http.Request, log logger.Logger, req Request) (ok bool) {
 	ctx := r.Context()
 
 	if err := r.ParseForm(); err != nil {

--- a/internal/web/utils/encode.go
+++ b/internal/web/utils/encode.go
@@ -4,11 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 )
 
 // EncodeResponse encodes response. It process error if needed
-func EncodeResponse(w http.ResponseWriter, r *http.Request, log logrus.FieldLogger, resp interface{}) (ok bool) {
+func EncodeResponse(w http.ResponseWriter, r *http.Request, log logger.Logger, resp interface{}) (ok bool) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		ProcessInternalError(r.Context(), log, w, "couldn't encode response", err)

--- a/internal/web/utils/error_processing.go
+++ b/internal/web/utils/error_processing.go
@@ -5,8 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
-
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/pkg/reqid"
 	"github.com/ShoshinNikita/budget-manager/internal/web/api/models"
 )
@@ -25,7 +24,7 @@ func ProcessError(ctx context.Context, w http.ResponseWriter, respMsg string, co
 
 // ProcessError logs internal error with 'LogInternalError' and calls 'ProcessError'
 // with 'http.StatusInternalServerError' status code
-func ProcessInternalError(ctx context.Context, log logrus.FieldLogger, w http.ResponseWriter,
+func ProcessInternalError(ctx context.Context, log logger.Logger, w http.ResponseWriter,
 	respMsg string, err error) {
 
 	LogInternalError(log, respMsg, err)
@@ -33,6 +32,6 @@ func ProcessInternalError(ctx context.Context, log logrus.FieldLogger, w http.Re
 	ProcessError(ctx, w, respMsg, http.StatusInternalServerError)
 }
 
-func LogInternalError(log logrus.FieldLogger, respMsg string, internalErr error) {
-	log.WithFields(logrus.Fields{"msg": respMsg, "error": internalErr}).Error("request error")
+func LogInternalError(log logger.Logger, respMsg string, internalErr error) {
+	log.WithFields(logger.Fields{"msg": respMsg, "error": internalErr}).Error("request error")
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -113,7 +113,6 @@ func (s *Server) Prepare() {
 	}
 
 	// Add API routes
-	s.log.Debug("add routes")
 	s.addRoutes(router)
 	if s.config.EnableProfiling {
 		// Enable pprof handlers
@@ -147,10 +146,5 @@ func (s Server) Shutdown() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
-	if err := s.server.Shutdown(ctx); err != nil {
-		s.log.WithError(err).Errorf("couldn't shutdown server gracefully")
-		return err
-	}
-
-	return nil
+	return s.server.Shutdown(ctx)
 }

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 	"github.com/ShoshinNikita/budget-manager/internal/web/api"
 	"github.com/ShoshinNikita/budget-manager/internal/web/pages"
 	"github.com/ShoshinNikita/budget-manager/static"
@@ -70,7 +70,7 @@ func (c *Credentials) UnmarshalText(text []byte) error {
 
 type Server struct {
 	config Config
-	log    logrus.FieldLogger
+	log    logger.Logger
 	db     Database
 
 	server *http.Server
@@ -84,7 +84,7 @@ type Database interface {
 	pages.DB
 }
 
-func NewServer(cnf Config, db Database, log logrus.FieldLogger, version, gitHash string) *Server {
+func NewServer(cnf Config, db Database, log logger.Logger, version, gitHash string) *Server {
 	return &Server{
 		config: cnf,
 		db:     db,

--- a/tests/prepare.go
+++ b/tests/prepare.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ShoshinNikita/budget-manager/internal/app"
+	"github.com/ShoshinNikita/budget-manager/internal/logger"
 )
 
 func prepareApp(t *testing.T, cfg *app.Config, components ...StartComponentFn) {
@@ -37,7 +37,7 @@ func prepareApp(t *testing.T, cfg *app.Config, components ...StartComponentFn) {
 
 	cfg.Server.Port = serverPort
 
-	app := app.NewApp(*cfg, logrus.New(), "", "")
+	app := app.NewApp(*cfg, logger.New(logger.Config{Level: "debug"}), "", "")
 	err := app.PrepareComponents()
 	require.NoError(err)
 


### PR DESCRIPTION
* Use interface `logging.Logger` instead of `*logrus.Logger` or `logrus.FieldLogger`
* Use method `logger.Logger.WithRequest` to add request fields to logger
* Remove excess logging & hide caller info